### PR TITLE
Refactor FDP projected expenses dashboard

### DIFF
--- a/mysite_PA_july11/condofix/bp_fonds_prevoyance/routes.py
+++ b/mysite_PA_july11/condofix/bp_fonds_prevoyance/routes.py
@@ -602,15 +602,15 @@ def depenses_fdp(usager):
     first_projected_year = min(projected_year_candidates) if projected_year_candidates else None
 
     fdp_date_warning = None
-    if (
-        usager == 'admin'
-        and first_projected_year is not None
-        and first_projected_year > annee_anal
-    ):
-        fdp_date_warning = (
-            f"À vérifier : la date d’analyse FDP est {annee_anal}, "
-            f"mais les interventions actives commencent en {first_projected_year}."
-        )
+
+    if usager == 'admin' and first_projected_year is not None:
+        fdp_gap_years = first_projected_year - annee_anal
+
+        if fdp_gap_years >= 3:
+            fdp_date_warning = (
+                f"À vérifier : la date d’analyse FDP est {annee_anal}, "
+                f"mais les interventions actives commencent en {first_projected_year}."
+            )
 
     # Dépenses réelles : tickets fermés de type Fonds de prévoyance
     # dans la fenêtre dynamique, jusqu'à la date courante.

--- a/mysite_PA_july11/condofix/bp_fonds_prevoyance/routes.py
+++ b/mysite_PA_july11/condofix/bp_fonds_prevoyance/routes.py
@@ -446,277 +446,554 @@ def calcul_dep(args):
 
     return res
 
-
-@bp_fonds_prevoyance.route('/depenses_fdp/<usager>', methods=['POST','GET'])
+@bp_fonds_prevoyance.route('/depenses_fdp/<usager>', methods=['POST', 'GET'])
 def depenses_fdp(usager):
-    """afficher la page des dépenses du fonds de prévoyance aux admin selon usager
-    'admin' ou 'coproprios'
+    """Afficher les dépenses projetées du fonds de prévoyance.
+
+    La même page est utilisée pour :
+    - admin : vue complète avec graphiques et calendrier projeté;
+    - coproprios sans restriction : vue complète avec graphiques et calendrier projeté;
+    - coproprios avec restriction : vue graphique seulement.
+
+    Les calculs financiers restent délégués à calcul_dep().
     """
 
     if session.get('ProfilUsager') is None:
-        # probablement délai de session atteint
         return render_template('session_ferme.html')
+
     profile_list = session.get('ProfilUsager')
-    # vérifier type d'usager (pas employé)
+
+    # Employés : accès non autorisé.
     if profile_list[2] == 3:
-            return redirect(url_for('bp_admin.permission'))
+        return redirect(url_for('bp_admin.permission'))
+
     client_ident = profile_list[0]
-
-     # ***************************préparation des données 25 ans du graphique histogramme de dépenses prévues
-    # processus de programmation:
-    # 1- appeler la fonction de calcul des interventions pour obtenir la liste complète 50 ans
-    # 2- supprimer les éléments de la liste ayant un 'an_prochain' plus grand que la période voulue
-    # 3- Créer les listes suivantes pour accumuler les données à afficher dans les graphiques:
-    #       - étiquettes d'années selon 'ans_traites' (1 liste)
-    #       - total annuel des valeurs actualisées pour les enregistrements pour chacun des 7 groupes Uniformat (7 listes)
-    #       IMPORTANT: toutes ces listes doivent avoir le même nombre d'éléments pour faire coincider les étiquettes
-    # 4- passer la liste dans une boucle avec 'ans_traites' croissants jusqu'au maximum
-    #   - pour chaque année de calendrier:
-    #       - multiplier la valeur de l'item par le taux d'inflation prévu selon le nombre d'années et selon la plage d'années applicables (0-5, 6-15, 16 et plus)
-    #       - cumuler les enregistrements ayant le même groupe pour l'année en cours de traitement
-    #       - ajouter ces cumuls à la liste du groupe applicable (voir item 8)
-
-    #1 Fonction de calcul préalable
-    if request.form.get('toggle')==None:
-        entite='syndicat'
-    else:
-        entite='coproprios'
-
-    # obtenir la liste des dépenses indexées pour prochains 50 ans
-    #liste_parametres=[usager, mode, taux_inflation]
-    parametres=[entite,'base',0]
-    res=calcul_dep(parametres)
-    fill_table=res[0]
-    fill_dep=res[0]
-    indices=res[1]
-    taux_infl_moyen_anal=indices[0]
-    croiss_ICC=indices[1]
-
     mode_connexion = profile_list[8]
+
+    # Vue financière affichée :
+    # - syndicat par défaut;
+    # - coproprios si la case "Vue copropriétaires" est cochée.
+    entite = 'coproprios' if request.form.get('toggle') else 'syndicat'
+
+    # Liste complète des dépenses indexées.
+    # calcul_dep() contient la logique financière existante :
+    # inflation, fréquence, part syndicat/copropriétaires, etc.
+    projection_rows_all, indices = calcul_dep([entite, 'base', 0])
+
     cnx = connect_db(mode_connexion)
     cur = cnx.cursor()
-    date_anal=datetime
 
-    cur.execute("SELECT DateAnalPrevoyance, AccesLimCoprop FROM parametres WHERE IDClient=%s", (client_ident,))
-    for item in cur.fetchall():
-        date_anal = item[0]
-        # pour coproprios, vérifier si accès limité dans paramètres
-        limite_acces = item[1]
+    cur.execute(
+        "SELECT DateAnalPrevoyance, AccesLimCoprop "
+        "FROM parametres "
+        "WHERE IDClient=%s",
+        (client_ident,)
+    )
+    parametres_fdp = cur.fetchone()
+
+    if parametres_fdp is None:
+        return render_template('session_ferme.html')
+
+    date_anal = parametres_fdp[0]
+    limite_acces = parametres_fdp[1] or 0
     annee_anal = date_anal.year
+    date_anal_label = date_anal.strftime('%Y-%m-%d')
 
-    # 2- supprimer les éléments de la liste ayant un 'an_prochain' plus grand que la période de 25 ans
-    indice = 0
+    # Fenêtre d'affichage : 25 ans à partir de la dernière analyse FDP.
+    # Important : le tableau doit recevoir cette liste filtrée, pas la liste complète
+    # retournée par calcul_dep(), sinon on affiche la projection complète.
     date_fin_brut = date_anal + relativedelta(years=24)
     annee_fin = date_fin_brut.year
-    for item in fill_dep:
-        #if item[4] > annee_fin:
-        if item[4] > date_fin_brut.strftime('%Y'):
-            del fill_dep[indice]
-        indice += 1
 
-    # 8- Créer les listes suivantes pour accumuler les données à afficher dans les graphiques:
-    #    étiquettes d'années selon 'ans_traites'
-    labels=[]
-    # total annuel des valeurs actualisées pour chaque groupe Uniformat
-    groupe_1=[]
-    groupe_2 = []
-    groupe_3 = []
-    groupe_4 = []
-    groupe_5 = []
-    groupe_6 = []
-    groupe_7 = []
-    groupe_8 = [] #autres
-    groupe_9 = []
-    cum_total_mtce=0
-    cum_total_rempl=0
+    projection_rows_visible = [
+        item for item in projection_rows_all
+        if int(item[4]) <= annee_fin
+    ]
 
-   #       IMPORTANT: toutes ces listes doivent avoir le même nombre d'éléments pour faire coincider les étiquettes
+    labels = []
+    groupes_projection = {group_id: [] for group_id in range(1, 10)}
 
-    # 9- passer la liste dans une boucle avec 'ans_traites' croissants jusqu'au maximum
-    #   - pour chaque année de calendrier:
-
-    annee_en_cours=annee_anal
-    indice=1
-    dep_tot_10_ans=[]
-    while annee_en_cours<=annee_fin:
-        # étiquettes des années:
+    # CONTENU DES ROWS DE calcul_dep() :
+    # 0 RefAnalyse
+    # 1 DescriptionDepense
+    # 2 FrequenceAns
+    # 3 Dépense actualisée
+    # 4 Année de l'intervention
+    # 5 Type d'intervention
+    # 6 Description catégorie
+    # 7 IDGroupe Uniformat
+    # 8 Description groupe Uniformat
+    # 9 Nom intervenant
+    for annee_en_cours in range(annee_anal, annee_fin + 1):
         labels.append(annee_en_cours)
-        # valeurs affichées par groupe
-        cum_1 = 0
-        cum_2 = 0
-        cum_3 = 0
-        cum_4 = 0
-        cum_5 = 0
-        cum_6 = 0
-        cum_7 = 0
-        cum_8 = 0
-        cum_9 = 0
-        # CONTENU DE L'AJOUT=  0 ref_analyse, 1 desc_intervention, 2 frequence, 3 dep_actualisee, 4 annee de l'intervention,
-        # 5 desc type intervention, 6 description categorie, 7 IDGroupe uniformat, 8 description groupe uniformat, 9 nom d'intervenant
 
-        for item in fill_dep:
-              if int(item[4])==int(annee_en_cours):
-                # cumul valeurs actualisées par année selon groupe Uniformat
+        cumuls = {group_id: 0.0 for group_id in range(1, 10)}
 
-                if int(item[7]) == 1:
-                    cum_1+= float(item[3])
+        for item in projection_rows_visible:
+            if int(item[4]) != annee_en_cours:
+                continue
 
-                elif int(item[7]) == 2:
-                    cum_2 += float(item[3])
+            try:
+                group_id = int(item[7])
+            except (TypeError, ValueError):
+                group_id = 8  # Autre
 
-                elif int(item[7]) == 3:
-                    cum_3 += float(item[3])
+            if group_id in cumuls:
+                cumuls[group_id] += float(item[3] or 0)
 
-                elif int(item[7]) == 4:
-                    cum_4 += float(item[3])
+        for group_id in range(1, 10):
+            groupes_projection[group_id].append(int(cumuls[group_id]))
 
-                elif int(item[7]) == 5:
-                    cum_5 += float(item[3])
+    # -------------------------------------------------------------------------
+    # Graphique réel vs prévu — fenêtre dynamique de 10 ans
+    #
+    # Le repère "Début FDP" doit représenter la date officielle de la dernière
+    # analyse du fonds de prévoyance, donc DateAnalPrevoyance. Ce repère est un
+    # jalon légal / administratif, et non la première année où une dépense est
+    # projetée.
+    #
+    # Fenêtre de base :
+    #   DateAnalPrevoyance - 5 ans à DateAnalPrevoyance + 4 ans.
+    #
+    # Pour éviter une fenêtre figée trop ancienne, on fait glisser la fenêtre si
+    # l'année courante dépasse la fin de cette période.
+    # -------------------------------------------------------------------------
+    current_year = datetime.now().year
+    current_date = datetime.now().date()
 
-                elif int(item[7]) == 6:
-                    cum_6 += float(item[3])
+    comparison_base_end_year = annee_anal + 4
+    comparison_end_year = max(comparison_base_end_year, current_year)
+    comparison_start_year = comparison_end_year - 9
+    fill_10_ans = list(range(comparison_start_year, comparison_end_year + 1))
 
-                elif int(item[7]) == 7:
-                    cum_7 += float(item[3])
+    groupes_prevus_10_ans = {group_id: [] for group_id in range(1, 10)}
 
-                elif int(item[7]) == 8:
-                    cum_8 += float(item[3])
+    for annee in fill_10_ans:
+        cumuls = {group_id: 0.0 for group_id in range(1, 10)}
 
-                elif int(item[7]) == 9:
-                    cum_9 += float(item[3])
-                # cumul par type d'intervention (mtce ou remplacement)
-                if item[5] == 'Maintenance':
-                    cum_total_mtce += float(item[3])
-                if item[5] == 'Remplacement':
-                    cum_total_rempl += float(item[3])
+        for item in projection_rows_all:
+            if int(item[4]) != annee:
+                continue
 
-        # cumul des dépenses totales prévues par année pour 10 ans pour graphique des actuelles vs. prévues
-        cum_global_annee=cum_1+cum_2+cum_3+cum_4+cum_5+cum_6+cum_7+cum_8+cum_9
-        if indice<11:
-            ajout_annee=(annee_en_cours,int(cum_global_annee))
-            dep_tot_10_ans.append(ajout_annee)
+            try:
+                group_id = int(item[7])
+            except (TypeError, ValueError):
+                group_id = 8  # Autre
 
+            if group_id in cumuls:
+                cumuls[group_id] += float(item[3] or 0)
 
-        # ajouter ces cumuls à la liste du groupe applicable
-        groupe_1.append(int(cum_1))
-        groupe_2.append(int(cum_2))
-        groupe_3.append(int(cum_3))
-        groupe_4.append(int(cum_4))
-        groupe_5.append(int(cum_5))
-        groupe_6.append(int(cum_6))
-        groupe_7.append(int(cum_7))
-        groupe_8.append(int(cum_8))
-        groupe_9.append(int(cum_9))
+        for group_id in range(1, 10):
+            groupes_prevus_10_ans[group_id].append(int(cumuls[group_id]))
 
-        annee_en_cours+=1
-        indice+=1
+    dep_10_ans = [
+        sum(groupes_prevus_10_ans[group_id][index] for group_id in range(1, 10))
+        for index in range(len(fill_10_ans))
+    ]
 
-    # ***************************préparation des données 10 ans du graphique de courbes de dépenses actuelles vs. prévues
+    # Avertissement admin seulement : utile lorsqu'une nouvelle analyse active a
+    # été importée, mais que DateAnalPrevoyance n'a pas encore été ajustée dans
+    # Paramètres > Fonds de prévoyance.
+    projected_year_candidates = [
+        int(item[4])
+        for item in projection_rows_all
+        if item[4] is not None and float(item[3] or 0) > 0
+    ]
+    first_projected_year = min(projected_year_candidates) if projected_year_candidates else None
 
-    fill_10_ans = []
-    dep_10_ans=[]
-    for item in dep_tot_10_ans:
-        #print('item dans dep_tot-10ans:',item)
-        fill_10_ans.append(item[0])
-        dep_10_ans.append(item[1])
-    #print ('liste 10 ans:',fill_10_ans)
+    fdp_date_warning = None
+    if (
+        usager == 'admin'
+        and first_projected_year is not None
+        and first_projected_year > annee_anal
+    ):
+        fdp_date_warning = (
+            f"À vérifier : la date d’analyse FDP est {annee_anal}, "
+            f"mais les interventions actives commencent en {first_projected_year}."
+        )
 
-    # obtenir dépenses des tickets fermés avec type de travail=2 (fonds de prévoyance)
-    fill_tickets=[]
-    cur.execute("SELECT DateComplet, CoutTotalTTC, IDCategorie FROM tickets WHERE TypeTravail=%s AND DateComplet>%s AND IDClient=%s",(2,date_anal,client_ident))
-    for item in cur.fetchall():
-        cur.execute("SELECT IDGroupe FROM categories WHERE IDCategorie=%s AND IDClient=%s",(item[2],client_ident))
-        for row in cur.fetchall():
-            # tenir compte des interventions dans parties communes à usage restreint ('Z') IDGroupe=9
-            if entite=='syndicat' and row[0]!=9:
-                ajout_ticket = (item[0].year, int(item[1]), row[0])
-                fill_tickets.append(ajout_ticket)
-            if entite == 'coproprios' and row[0] == 9:
-                ajout_ticket = (item[0].year, int(item[1]), row[0])
-                fill_tickets.append(ajout_ticket)
+    # Dépenses réelles : tickets fermés de type Fonds de prévoyance
+    # dans la fenêtre dynamique, jusqu'à la date courante.
+    fill_tickets = []
 
-    groupe_1_act=[]
-    groupe_2_act = []
-    groupe_3_act = []
-    groupe_4_act = []
-    groupe_5_act = []
-    groupe_6_act = []
-    groupe_7_act = []
-    groupe_8_act = []
-    groupe_9_act = []
+    cur.execute(
+        "SELECT YEAR(t.DateComplet), t.CoutTotalTTC, COALESCE(c.IDGroupe, 8) "
+        "FROM tickets t "
+        "LEFT JOIN categories c "
+        "  ON c.IDCategorie = t.IDCategorie "
+        " AND c.IDClient = t.IDClient "
+        "WHERE t.TypeTravail=%s "
+        "  AND t.IDClient=%s "
+        "  AND t.DateComplet IS NOT NULL "
+        "  AND t.DateComplet >= %s "
+        "  AND t.DateComplet <= %s",
+        (
+            2,
+            client_ident,
+            f"{comparison_start_year}-01-01",
+            current_date,
+        )
+    )
 
-    for item in fill_10_ans:
-        cum_dep_act_1 = 0
-        cum_dep_act_2 = 0
-        cum_dep_act_3 = 0
-        cum_dep_act_4 = 0
-        cum_dep_act_5 = 0
-        cum_dep_act_6 = 0
-        cum_dep_act_7 = 0
-        cum_dep_act_8 = 0
-        cum_dep_act_9 = 0
-        for unit in fill_tickets:
-            if unit[0]==item:
-                  if unit[2]==1:
-                      cum_dep_act_1+=unit[1]
-                  if unit[2]==2:
-                      cum_dep_act_2+=unit[1]
-                  if unit[2]==3:
-                      cum_dep_act_3+=unit[1]
-                  if unit[2]==4:
-                      cum_dep_act_4+=unit[1]
-                  if unit[2]==5:
-                      cum_dep_act_5+=unit[1]
-                  if unit[2]==6:
-                      cum_dep_act_6+=unit[1]
-                  if unit[2]==7:
-                      cum_dep_act_7+=unit[1]
-                  if unit[2] == 8:
-                      cum_dep_act_8 += unit[1]
-                  if unit[2] == 9:
-                      cum_dep_act_9 += unit[1]
-        groupe_1_act.append(cum_dep_act_1)
-        groupe_2_act.append(cum_dep_act_2)
-        groupe_3_act.append(cum_dep_act_3)
-        groupe_4_act.append(cum_dep_act_4)
-        groupe_5_act.append(cum_dep_act_5)
-        groupe_6_act.append(cum_dep_act_6)
-        groupe_7_act.append(cum_dep_act_7)
-        groupe_8_act.append(cum_dep_act_8)
-        groupe_9_act.append(cum_dep_act_9)
+    for ticket_year, ticket_cost, group_id in cur.fetchall():
+        if entite == 'syndicat' and group_id != 9:
+            fill_tickets.append((ticket_year, int(ticket_cost or 0), group_id))
 
-#***************************remplissage de la table dynamique des dépenses prévues au bas de la page
+        if entite == 'coproprios' and group_id == 9:
+            fill_tickets.append((ticket_year, int(ticket_cost or 0), group_id))
 
-    #vérifier si pour coproprios ou admin. Si coproprio, vérifier si accès limité dans paramètres
+    groupes_reels = {group_id: [] for group_id in range(1, 10)}
+
+    for annee in fill_10_ans:
+        cumuls = {group_id: 0 for group_id in range(1, 10)}
+
+        for ticket_year, ticket_amount, group_id in fill_tickets:
+            if ticket_year == annee and group_id in cumuls:
+                cumuls[group_id] += ticket_amount
+
+        for group_id in range(1, 10):
+            groupes_reels[group_id].append(cumuls[group_id])
+
+    template_args = dict(
+        labels=labels,
+        values_1=groupes_projection[1],
+        values_2=groupes_projection[2],
+        values_3=groupes_projection[3],
+        values_4=groupes_projection[4],
+        values_5=groupes_projection[5],
+        values_6=groupes_projection[6],
+        values_7=groupes_projection[7],
+        values_8=groupes_projection[8],
+        values_9=groupes_projection[9],
+
+        # Important :
+        # projection_rows_visible = même fenêtre 25 ans que le graphique principal.
+        # projection_rows_all serait la projection complète retournée par calcul_dep().
+        fill_table=projection_rows_visible,
+
+        toggle=entite,
+        labels_1=fill_10_ans,
+        dep_prevues=dep_10_ans,
+
+        prev_grp_1=groupes_prevus_10_ans[1],
+        prev_grp_2=groupes_prevus_10_ans[2],
+        prev_grp_3=groupes_prevus_10_ans[3],
+        prev_grp_4=groupes_prevus_10_ans[4],
+        prev_grp_5=groupes_prevus_10_ans[5],
+        prev_grp_6=groupes_prevus_10_ans[6],
+        prev_grp_7=groupes_prevus_10_ans[7],
+        prev_grp_8=groupes_prevus_10_ans[8],
+        prev_grp_9=groupes_prevus_10_ans[9],
+
+        dep_grp_1=groupes_reels[1],
+        dep_grp_2=groupes_reels[2],
+        dep_grp_3=groupes_reels[3],
+        dep_grp_4=groupes_reels[4],
+        dep_grp_5=groupes_reels[5],
+        dep_grp_6=groupes_reels[6],
+        dep_grp_7=groupes_reels[7],
+        dep_grp_8=groupes_reels[8],
+        dep_grp_9=groupes_reels[9],
+
+        fdp_start_year=annee_anal,
+        fdp_start_date_label=date_anal_label,
+        current_year=current_year,
+        fdp_date_warning=fdp_date_warning,
+        bd=profile_list[3],
+    )
+
+    if usager == 'admin':
+        return render_template(
+            'graph_fdp_dep.html',
+            base_layout='layout_admin_tables.html',
+            fdp_usager='admin',
+            show_projected_table=True,
+            **template_args
+        )
+
     if usager == 'coproprios':
-        if limite_acces==1:
-            return render_template('graph_fdp_dep_limite.html', labels=labels,
-                                   values_1=groupe_1, values_2=groupe_2, values_3=groupe_3, values_4=groupe_4,
-                                   values_5=groupe_5,
-                                   values_6=groupe_6, values_7=groupe_7, values_8=groupe_8, values_9=groupe_9, fill_table=fill_table, labels_1=fill_10_ans,
-                                   dep_prevues=dep_10_ans, toggle=entite,
-                                   dep_grp_1=groupe_1_act, dep_grp_2=groupe_2_act, dep_grp_3=groupe_3_act,
-                                   dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act, dep_grp_6=groupe_6_act,
-                                   dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act,
-                                   bd=profile_list[3])
-        else: # pas de restriction
-            return render_template('graph_fdp_dep_proprios.html', labels=labels, values_1=groupe_1, values_2=groupe_2,
-                                   values_3=groupe_3,
-                                   values_4=groupe_4, values_5=groupe_5, values_6=groupe_6, values_7=groupe_7, values_8=groupe_8,
-                                   values_9=groupe_9, fill_table=fill_table, toggle=entite,
-                                   labels_1=fill_10_ans, dep_prevues=dep_10_ans, dep_grp_1=groupe_1_act,
-                                   dep_grp_2=groupe_2_act,
-                                   dep_grp_3=groupe_3_act, dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act,
-                                   dep_grp_6=groupe_6_act,
-                                   dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act, bd=profile_list[3])
+        return render_template(
+            'graph_fdp_dep.html',
+            base_layout='proprios_layout_tables.html',
+            fdp_usager='coproprios',
+            show_projected_table=(limite_acces != 1),
+            **template_args
+        )
 
-    if usager=='admin':
-        return render_template('graph_fdp_dep_admin.html',labels=labels, values_1=groupe_1, values_2=groupe_2,values_3=groupe_3,
-                               values_4=groupe_4,values_5=groupe_5,values_6=groupe_6,values_7=groupe_7,values_8=groupe_8,values_9=groupe_9,
-                                fill_table=fill_table, toggle=entite,
-                               labels_1=fill_10_ans, dep_prevues=dep_10_ans, dep_grp_1=groupe_1_act, dep_grp_2=groupe_2_act,
-                               dep_grp_3=groupe_3_act, dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act, dep_grp_6=groupe_6_act,
-                               dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act, bd=profile_list[3])
+    return redirect(url_for('bp_admin.permission'))
+
+
+
+# @bp_fonds_prevoyance.route('/depenses_fdp/<usager>', methods=['POST','GET'])
+# def depenses_fdp(usager):
+#     """afficher la page des dépenses du fonds de prévoyance aux admin selon usager
+#     'admin' ou 'coproprios'
+#     """
+#
+#     if session.get('ProfilUsager') is None:
+#         # probablement délai de session atteint
+#         return render_template('session_ferme.html')
+#     profile_list = session.get('ProfilUsager')
+#     # vérifier type d'usager (pas employé)
+#     if profile_list[2] == 3:
+#             return redirect(url_for('bp_admin.permission'))
+#     client_ident = profile_list[0]
+#
+#      # ***************************préparation des données 25 ans du graphique histogramme de dépenses prévues
+#     # processus de programmation:
+#     # 1- appeler la fonction de calcul des interventions pour obtenir la liste complète 50 ans
+#     # 2- supprimer les éléments de la liste ayant un 'an_prochain' plus grand que la période voulue
+#     # 3- Créer les listes suivantes pour accumuler les données à afficher dans les graphiques:
+#     #       - étiquettes d'années selon 'ans_traites' (1 liste)
+#     #       - total annuel des valeurs actualisées pour les enregistrements pour chacun des 7 groupes Uniformat (7 listes)
+#     #       IMPORTANT: toutes ces listes doivent avoir le même nombre d'éléments pour faire coincider les étiquettes
+#     # 4- passer la liste dans une boucle avec 'ans_traites' croissants jusqu'au maximum
+#     #   - pour chaque année de calendrier:
+#     #       - multiplier la valeur de l'item par le taux d'inflation prévu selon le nombre d'années et selon la plage d'années applicables (0-5, 6-15, 16 et plus)
+#     #       - cumuler les enregistrements ayant le même groupe pour l'année en cours de traitement
+#     #       - ajouter ces cumuls à la liste du groupe applicable (voir item 8)
+#
+#     #1 Fonction de calcul préalable
+#     if request.form.get('toggle')==None:
+#         entite='syndicat'
+#     else:
+#         entite='coproprios'
+#
+#     # obtenir la liste des dépenses indexées pour prochains 50 ans
+#     #liste_parametres=[usager, mode, taux_inflation]
+#     parametres=[entite,'base',0]
+#     res=calcul_dep(parametres)
+#     fill_table=res[0]
+#     fill_dep=res[0]
+#     indices=res[1]
+#     taux_infl_moyen_anal=indices[0]
+#     croiss_ICC=indices[1]
+#
+#     mode_connexion = profile_list[8]
+#     cnx = connect_db(mode_connexion)
+#     cur = cnx.cursor()
+#     date_anal=datetime
+#
+#     cur.execute("SELECT DateAnalPrevoyance, AccesLimCoprop FROM parametres WHERE IDClient=%s", (client_ident,))
+#     for item in cur.fetchall():
+#         date_anal = item[0]
+#         # pour coproprios, vérifier si accès limité dans paramètres
+#         limite_acces = item[1]
+#     annee_anal = date_anal.year
+#
+#     # 2- supprimer les éléments de la liste ayant un 'an_prochain' plus grand que la période de 25 ans
+#     indice = 0
+#     date_fin_brut = date_anal + relativedelta(years=24)
+#     annee_fin = date_fin_brut.year
+#     for item in fill_dep:
+#         #if item[4] > annee_fin:
+#         if item[4] > date_fin_brut.strftime('%Y'):
+#             del fill_dep[indice]
+#         indice += 1
+#
+#     # 8- Créer les listes suivantes pour accumuler les données à afficher dans les graphiques:
+#     #    étiquettes d'années selon 'ans_traites'
+#     labels=[]
+#     # total annuel des valeurs actualisées pour chaque groupe Uniformat
+#     groupe_1=[]
+#     groupe_2 = []
+#     groupe_3 = []
+#     groupe_4 = []
+#     groupe_5 = []
+#     groupe_6 = []
+#     groupe_7 = []
+#     groupe_8 = [] #autres
+#     groupe_9 = []
+#     cum_total_mtce=0
+#     cum_total_rempl=0
+#
+#    #       IMPORTANT: toutes ces listes doivent avoir le même nombre d'éléments pour faire coincider les étiquettes
+#
+#     # 9- passer la liste dans une boucle avec 'ans_traites' croissants jusqu'au maximum
+#     #   - pour chaque année de calendrier:
+#
+#     annee_en_cours=annee_anal
+#     indice=1
+#     dep_tot_10_ans=[]
+#     while annee_en_cours<=annee_fin:
+#         # étiquettes des années:
+#         labels.append(annee_en_cours)
+#         # valeurs affichées par groupe
+#         cum_1 = 0
+#         cum_2 = 0
+#         cum_3 = 0
+#         cum_4 = 0
+#         cum_5 = 0
+#         cum_6 = 0
+#         cum_7 = 0
+#         cum_8 = 0
+#         cum_9 = 0
+#         # CONTENU DE L'AJOUT=  0 ref_analyse, 1 desc_intervention, 2 frequence, 3 dep_actualisee, 4 annee de l'intervention,
+#         # 5 desc type intervention, 6 description categorie, 7 IDGroupe uniformat, 8 description groupe uniformat, 9 nom d'intervenant
+#
+#         for item in fill_dep:
+#               if int(item[4])==int(annee_en_cours):
+#                 # cumul valeurs actualisées par année selon groupe Uniformat
+#
+#                 if int(item[7]) == 1:
+#                     cum_1+= float(item[3])
+#
+#                 elif int(item[7]) == 2:
+#                     cum_2 += float(item[3])
+#
+#                 elif int(item[7]) == 3:
+#                     cum_3 += float(item[3])
+#
+#                 elif int(item[7]) == 4:
+#                     cum_4 += float(item[3])
+#
+#                 elif int(item[7]) == 5:
+#                     cum_5 += float(item[3])
+#
+#                 elif int(item[7]) == 6:
+#                     cum_6 += float(item[3])
+#
+#                 elif int(item[7]) == 7:
+#                     cum_7 += float(item[3])
+#
+#                 elif int(item[7]) == 8:
+#                     cum_8 += float(item[3])
+#
+#                 elif int(item[7]) == 9:
+#                     cum_9 += float(item[3])
+#                 # cumul par type d'intervention (mtce ou remplacement)
+#                 if item[5] == 'Maintenance':
+#                     cum_total_mtce += float(item[3])
+#                 if item[5] == 'Remplacement':
+#                     cum_total_rempl += float(item[3])
+#
+#         # cumul des dépenses totales prévues par année pour 10 ans pour graphique des actuelles vs. prévues
+#         cum_global_annee=cum_1+cum_2+cum_3+cum_4+cum_5+cum_6+cum_7+cum_8+cum_9
+#         if indice<11:
+#             ajout_annee=(annee_en_cours,int(cum_global_annee))
+#             dep_tot_10_ans.append(ajout_annee)
+#
+#
+#         # ajouter ces cumuls à la liste du groupe applicable
+#         groupe_1.append(int(cum_1))
+#         groupe_2.append(int(cum_2))
+#         groupe_3.append(int(cum_3))
+#         groupe_4.append(int(cum_4))
+#         groupe_5.append(int(cum_5))
+#         groupe_6.append(int(cum_6))
+#         groupe_7.append(int(cum_7))
+#         groupe_8.append(int(cum_8))
+#         groupe_9.append(int(cum_9))
+#
+#         annee_en_cours+=1
+#         indice+=1
+#
+#     # ***************************préparation des données 10 ans du graphique de courbes de dépenses actuelles vs. prévues
+#
+#     fill_10_ans = []
+#     dep_10_ans=[]
+#     for item in dep_tot_10_ans:
+#         #print('item dans dep_tot-10ans:',item)
+#         fill_10_ans.append(item[0])
+#         dep_10_ans.append(item[1])
+#     #print ('liste 10 ans:',fill_10_ans)
+#
+#     # obtenir dépenses des tickets fermés avec type de travail=2 (fonds de prévoyance)
+#     fill_tickets=[]
+#     cur.execute("SELECT DateComplet, CoutTotalTTC, IDCategorie FROM tickets WHERE TypeTravail=%s AND DateComplet>%s AND IDClient=%s",(2,date_anal,client_ident))
+#     for item in cur.fetchall():
+#         cur.execute("SELECT IDGroupe FROM categories WHERE IDCategorie=%s AND IDClient=%s",(item[2],client_ident))
+#         for row in cur.fetchall():
+#             # tenir compte des interventions dans parties communes à usage restreint ('Z') IDGroupe=9
+#             if entite=='syndicat' and row[0]!=9:
+#                 ajout_ticket = (item[0].year, int(item[1]), row[0])
+#                 fill_tickets.append(ajout_ticket)
+#             if entite == 'coproprios' and row[0] == 9:
+#                 ajout_ticket = (item[0].year, int(item[1]), row[0])
+#                 fill_tickets.append(ajout_ticket)
+#
+#     groupe_1_act=[]
+#     groupe_2_act = []
+#     groupe_3_act = []
+#     groupe_4_act = []
+#     groupe_5_act = []
+#     groupe_6_act = []
+#     groupe_7_act = []
+#     groupe_8_act = []
+#     groupe_9_act = []
+#
+#     for item in fill_10_ans:
+#         cum_dep_act_1 = 0
+#         cum_dep_act_2 = 0
+#         cum_dep_act_3 = 0
+#         cum_dep_act_4 = 0
+#         cum_dep_act_5 = 0
+#         cum_dep_act_6 = 0
+#         cum_dep_act_7 = 0
+#         cum_dep_act_8 = 0
+#         cum_dep_act_9 = 0
+#         for unit in fill_tickets:
+#             if unit[0]==item:
+#                   if unit[2]==1:
+#                       cum_dep_act_1+=unit[1]
+#                   if unit[2]==2:
+#                       cum_dep_act_2+=unit[1]
+#                   if unit[2]==3:
+#                       cum_dep_act_3+=unit[1]
+#                   if unit[2]==4:
+#                       cum_dep_act_4+=unit[1]
+#                   if unit[2]==5:
+#                       cum_dep_act_5+=unit[1]
+#                   if unit[2]==6:
+#                       cum_dep_act_6+=unit[1]
+#                   if unit[2]==7:
+#                       cum_dep_act_7+=unit[1]
+#                   if unit[2] == 8:
+#                       cum_dep_act_8 += unit[1]
+#                   if unit[2] == 9:
+#                       cum_dep_act_9 += unit[1]
+#         groupe_1_act.append(cum_dep_act_1)
+#         groupe_2_act.append(cum_dep_act_2)
+#         groupe_3_act.append(cum_dep_act_3)
+#         groupe_4_act.append(cum_dep_act_4)
+#         groupe_5_act.append(cum_dep_act_5)
+#         groupe_6_act.append(cum_dep_act_6)
+#         groupe_7_act.append(cum_dep_act_7)
+#         groupe_8_act.append(cum_dep_act_8)
+#         groupe_9_act.append(cum_dep_act_9)
+#
+# #***************************remplissage de la table dynamique des dépenses prévues au bas de la page
+#
+#     #vérifier si pour coproprios ou admin. Si coproprio, vérifier si accès limité dans paramètres
+#     if usager == 'coproprios':
+#         if limite_acces==1:
+#             return render_template('graph_fdp_dep_limite.html', labels=labels,
+#                                    values_1=groupe_1, values_2=groupe_2, values_3=groupe_3, values_4=groupe_4,
+#                                    values_5=groupe_5,
+#                                    values_6=groupe_6, values_7=groupe_7, values_8=groupe_8, values_9=groupe_9, fill_table=fill_table, labels_1=fill_10_ans,
+#                                    dep_prevues=dep_10_ans, toggle=entite,
+#                                    dep_grp_1=groupe_1_act, dep_grp_2=groupe_2_act, dep_grp_3=groupe_3_act,
+#                                    dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act, dep_grp_6=groupe_6_act,
+#                                    dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act,
+#                                    bd=profile_list[3])
+#         else: # pas de restriction
+#             return render_template('graph_fdp_dep_proprios.html', labels=labels, values_1=groupe_1, values_2=groupe_2,
+#                                    values_3=groupe_3,
+#                                    values_4=groupe_4, values_5=groupe_5, values_6=groupe_6, values_7=groupe_7, values_8=groupe_8,
+#                                    values_9=groupe_9, fill_table=fill_table, toggle=entite,
+#                                    labels_1=fill_10_ans, dep_prevues=dep_10_ans, dep_grp_1=groupe_1_act,
+#                                    dep_grp_2=groupe_2_act,
+#                                    dep_grp_3=groupe_3_act, dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act,
+#                                    dep_grp_6=groupe_6_act,
+#                                    dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act, bd=profile_list[3])
+#
+#     if usager=='admin':
+#         return render_template('graph_fdp_dep_admin.html',labels=labels, values_1=groupe_1, values_2=groupe_2,values_3=groupe_3,
+#                                values_4=groupe_4,values_5=groupe_5,values_6=groupe_6,values_7=groupe_7,values_8=groupe_8,values_9=groupe_9,
+#                                 fill_table=fill_table, toggle=entite,
+#                                labels_1=fill_10_ans, dep_prevues=dep_10_ans, dep_grp_1=groupe_1_act, dep_grp_2=groupe_2_act,
+#                                dep_grp_3=groupe_3_act, dep_grp_4=groupe_4_act, dep_grp_5=groupe_5_act, dep_grp_6=groupe_6_act,
+#                                dep_grp_7=groupe_7_act, dep_grp_8=groupe_8_act, dep_grp_9=groupe_9_act, bd=profile_list[3])
 
 #****************************Page affichant le solde du fonds et les dépenses selon l'analyse ou la modélisation*******************
 @bp_fonds_prevoyance.route('/calcul_solde/<args>', methods=['POST','GET'])

--- a/mysite_PA_july11/condofix/templates/graph_fdp_dep.html
+++ b/mysite_PA_july11/condofix/templates/graph_fdp_dep.html
@@ -1,0 +1,1354 @@
+{% extends base_layout %}
+{% block content %}
+
+<!-- DataTables -->
+<script src="../static/DataTables/DataTables_with_buttons/jquery-3.5.1.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/jquery.dataTables.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/dataTables.buttons.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/jszip.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/pdfmake.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/vfs_fonts.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/buttons.html5.min.js"></script>
+
+<!-- Bootstrap JS -->
+<script src="../static/bootstrap-4.1.3-dist/js/bootstrap.min.js"></script>
+
+<!-- Chart.js -->
+<script src="../static/Chart.min.js"></script>
+
+<!-- DataTables CSS -->
+<link href="../static/DataTables/DataTables_with_buttons/css/jquery.dataTables.min.css" rel="stylesheet" />
+<link href="../static/DataTables/DataTables_with_buttons/css/buttons.dataTables.min.css" rel="stylesheet" />
+
+<style>
+    .fdp-dep-page {
+        --fdp-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+        --fdp-soft-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+        --fdp-radius-xl: 20px;
+        --fdp-radius-lg: 16px;
+        --fdp-radius-md: 14px;
+        --fdp-radius-sm: 12px;
+        color: var(--theme-text);
+        padding: 1.25rem 0 2rem;
+    }
+
+    .fdp-dep-page .fdp-shell,
+    .fdp-dep-page .fdp-card {
+        background: var(--theme-surface);
+        border: 1px solid var(--theme-border);
+        box-shadow: var(--fdp-shadow);
+    }
+
+    .fdp-dep-page .fdp-shell {
+        border-radius: var(--fdp-radius-xl);
+        padding: 1.25rem;
+    }
+
+    .fdp-dep-page .fdp-card {
+        border-radius: var(--fdp-radius-lg);
+        padding: 1rem;
+        height: 100%;
+    }
+
+    .fdp-dep-page .fdp-page-header,
+    .fdp-dep-page .fdp-toolbar {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+
+    .fdp-dep-page h1 {
+        margin: 0;
+        color: var(--theme-text);
+        font-size: 1.95rem;
+        font-weight: 800;
+        line-height: 1.1;
+    }
+
+    .fdp-dep-page h2 {
+        margin: 0 0 0.35rem;
+        color: var(--theme-text);
+        font-size: 1.2rem;
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-muted {
+        margin: 0.35rem 0 0;
+        color: var(--theme-text-muted);
+        font-size: 0.98rem;
+    }
+
+    .fdp-dep-page .fdp-view-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        min-height: 44px;
+        padding: 0.55rem 0.85rem;
+        border: 1px solid var(--theme-border);
+        border-radius: var(--fdp-radius-md);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+        cursor: pointer;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page .fdp-view-toggle input {
+        width: 16px;
+        height: 16px;
+        margin: 0;
+        accent-color: var(--theme-link-edit);
+    }
+
+    .fdp-dep-page .fdp-kpi-grid {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(150px, 1fr));
+        gap: 0.75rem;
+        margin: 1rem 0;
+    }
+
+    .fdp-dep-page .fdp-kpi {
+        min-height: 88px;
+        padding: 0.85rem 1rem;
+        border: 0;
+        border-radius: var(--fdp-radius-lg);
+        color: #fff;
+        box-shadow: var(--fdp-soft-shadow);
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    }
+
+    .fdp-dep-page .fdp-kpi:hover,
+    .fdp-dep-page .fdp-kpi:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 22px rgba(15, 23, 42, 0.14);
+        outline: none;
+    }
+
+    .fdp-dep-page .fdp-kpi-label {
+        display: block;
+        font-size: 0.72rem;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.035em;
+    }
+
+    .fdp-dep-page .fdp-kpi-value {
+        display: block;
+        margin-top: 0.25rem;
+        font-size: 1.45rem;
+        font-weight: 900;
+        line-height: 1.05;
+    }
+
+    .fdp-dep-page .fdp-kpi-sub {
+        display: block;
+        margin-top: 0.25rem;
+        font-size: 0.78rem;
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-kpi-total { background: linear-gradient(135deg, var(--theme-priority-medium), var(--theme-link-edit)); color: var(--theme-priority-medium-text); }
+    .fdp-dep-page .fdp-kpi-next { background: linear-gradient(135deg, var(--theme-priority-high), var(--theme-link-complete)); color: var(--theme-priority-high-text); }
+    .fdp-dep-page .fdp-kpi-peak { background: linear-gradient(135deg, var(--theme-priority-critical), var(--theme-link-delete)); color: var(--theme-priority-critical-text); }
+    .fdp-dep-page .fdp-kpi-group { background: linear-gradient(135deg, var(--theme-priority-low), var(--theme-chart-equipment)); color: var(--theme-priority-low-text); }
+    .fdp-dep-page .fdp-kpi-count { background: linear-gradient(135deg, var(--theme-kpi-hours), var(--theme-chart-budget)); color: var(--theme-kpi-hours-text); }
+
+    .fdp-dep-page .fdp-banner,
+    .fdp-dep-page .fdp-active-filter {
+        padding: 0.85rem 1rem;
+        border-radius: var(--fdp-radius-md);
+        border: 1px dashed var(--theme-border);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-banner { margin-bottom: 1rem; }
+
+    .fdp-dep-page .fdp-warning {
+        margin-bottom: 1rem;
+        padding: 0.85rem 1rem;
+        border-radius: var(--fdp-radius-md);
+        border: 1px solid var(--theme-border);
+        border-left: 5px solid var(--theme-priority-high);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-warning strong {
+        color: var(--theme-text);
+    }
+
+    .fdp-dep-page .fdp-filter-card {
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border-radius: var(--fdp-radius-lg);
+        border: 1px solid var(--theme-border);
+        background: var(--theme-surface);
+        box-shadow: var(--fdp-soft-shadow);
+    }
+
+    .fdp-dep-page .fdp-filter-title {
+        margin: 0 0 0.75rem;
+        color: var(--theme-text);
+        font-weight: 900;
+    }
+
+    .fdp-dep-page .fdp-chip-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .fdp-dep-page .fdp-chip {
+        min-height: 34px;
+        padding: 0.4rem 0.72rem;
+        border-radius: 999px;
+        border: 1px solid var(--theme-border);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+        font-size: 0.84rem;
+        cursor: pointer;
+        transition: all 0.15s ease-in-out;
+    }
+
+    .fdp-dep-page .fdp-chip:hover,
+    .fdp-dep-page .fdp-chip:focus {
+        transform: translateY(-1px);
+        box-shadow: var(--fdp-soft-shadow);
+        outline: none;
+    }
+
+    .fdp-dep-page .fdp-chip.active {
+        background: var(--theme-link-edit);
+        border-color: var(--theme-link-edit);
+        color: #fff;
+    }
+
+    .fdp-dep-page .fdp-chart-wrap {
+        position: relative;
+        width: 100%;
+        height: 305px;
+    }
+
+    .fdp-dep-page .fdp-chart-wrap canvas {
+        display: block !important;
+        width: 100% !important;
+        height: 100% !important;
+    }
+
+    .fdp-dep-page .fdp-table-card {
+        border-radius: var(--fdp-radius-lg);
+        overflow: hidden;
+    }
+
+    .fdp-dep-page .fdp-table-scroll-top,
+    .fdp-dep-page .fdp-table-scroll {
+        width: 100%;
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .fdp-dep-page .fdp-table-scroll-top { height: 18px; margin-bottom: 8px; }
+    .fdp-dep-page .fdp-table-scroll-top-inner { height: 1px; min-width: 1250px; }
+    .fdp-dep-page .fdp-table-scroll table { min-width: 1250px !important; }
+
+    .fdp-dep-page .fdp-toolbar { align-items: center; margin: 0.5rem 0 1rem; }
+    .fdp-dep-page .fdp-toolbar-left,
+    .fdp-dep-page .fdp-toolbar-right { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+
+    .fdp-dep-page .dt-buttons .dt-button {
+        min-height: 42px;
+        padding: 0.6rem 1rem;
+        border-radius: var(--fdp-radius-sm);
+        border: 1px solid var(--theme-border) !important;
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        font-weight: 800 !important;
+        box-shadow: none !important;
+        margin: 0 !important;
+    }
+
+    .fdp-dep-page #fdp-dt-search .dataTables_filter label,
+    .fdp-dep-page .dataTables_wrapper .dataTables_filter label {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+        margin: 0;
+        color: var(--theme-text-muted);
+        font-weight: 800;
+    }
+
+    .fdp-dep-page #fdp-dt-search .dataTables_filter input,
+    .fdp-dep-page .dataTables_wrapper .dataTables_filter input {
+        margin-left: 0 !important;
+        width: 260px !important;
+        min-height: 44px !important;
+        padding: 0.65rem 0.95rem !important;
+        border-radius: 14px !important;
+        border: 1px solid var(--theme-border) !important;
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        outline: none !important;
+        box-shadow: none !important;
+    }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_length,
+    .fdp-dep-page .dataTables_wrapper .dataTables_info,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate { color: var(--theme-text-muted) !important; }
+
+    .fdp-dep-page table.dataTable,
+    .fdp-dep-page table#table_data {
+        width: 100% !important;
+        margin: 0 !important;
+        border-collapse: separate !important;
+        border-spacing: 0 !important;
+        font-family: Inter, "Segoe UI", Arial, sans-serif;
+        font-size: 0.94rem;
+        border: 0 !important;
+    }
+
+    .fdp-dep-page table.dataTable thead th,
+    .fdp-dep-page table#table_data thead th {
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        border-bottom: 1px solid var(--theme-border) !important;
+        border-right: 0 !important;
+        padding: 14px 26px 14px 12px !important;
+        font-size: 0.9rem;
+        font-weight: 900;
+        vertical-align: middle;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page table.dataTable tbody td,
+    .fdp-dep-page table#table_data tbody td {
+        background: var(--theme-surface) !important;
+        color: var(--theme-text) !important;
+        border-top: 0 !important;
+        border-right: 0 !important;
+        border-left: 0 !important;
+        border-bottom: 1px solid var(--theme-border) !important;
+        padding: 14px 12px !important;
+        vertical-align: top;
+    }
+
+    .fdp-dep-page table.dataTable tbody tr:nth-child(even) td,
+    .fdp-dep-page table#table_data tbody tr:nth-child(even) td { background: rgba(127, 145, 168, 0.05) !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_length { padding: 1rem 0.5rem 0.75rem !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_info { padding: 1.2rem 0.5rem 0.6rem !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate { padding: 1rem 0.5rem 0.75rem !important; }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button {
+        border-radius: 10px !important;
+        border: 1px solid transparent !important;
+        color: var(--theme-text) !important;
+        padding: 0.45rem 0.8rem !important;
+        margin-left: 0.2rem !important;
+    }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button.current,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+        background: var(--theme-surface-alt) !important;
+        border-color: var(--theme-border) !important;
+        color: var(--theme-text) !important;
+    }
+
+    .fdp-dep-page .fdp-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 24px;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.78rem;
+        font-weight: 900;
+        line-height: 1.1;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page .fdp-pill-maintenance { color: var(--theme-link-edit); background: rgba(13, 110, 253, 0.12); }
+    .fdp-dep-page .fdp-pill-remplacement { color: var(--theme-link-complete); background: rgba(245, 158, 11, 0.14); }
+    .fdp-dep-page .fdp-pill-group { color: var(--theme-text); background: var(--theme-surface-alt); border: 1px solid var(--theme-border); }
+    .fdp-dep-page .fdp-money,
+    .fdp-dep-page .fdp-year { font-weight: 900; white-space: nowrap; }
+
+    .fdp-dep-page .fdp-active-filter { display: none; margin-bottom: 0.9rem; }
+    .fdp-dep-page .fdp-active-filter.show { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
+    .fdp-dep-page .fdp-clear-filter { border: 0; background: transparent; color: var(--theme-link-edit); font-weight: 900; cursor: pointer; padding: 0; }
+
+    @media (max-width: 1200px) { .fdp-dep-page .fdp-kpi-grid { grid-template-columns: repeat(3, minmax(150px, 1fr)); } }
+    @media (max-width: 991px) { .fdp-dep-page .fdp-chart-wrap { height: 270px; } }
+    @media (max-width: 768px) {
+        .fdp-dep-page .fdp-shell { padding: 1rem; border-radius: 16px; }
+        .fdp-dep-page h1 { font-size: 1.6rem; }
+        .fdp-dep-page .fdp-kpi-grid { grid-template-columns: repeat(2, minmax(140px, 1fr)); }
+    }
+    @media (max-width: 575px) {
+        .fdp-dep-page .fdp-kpi-grid { grid-template-columns: 1fr; }
+        .fdp-dep-page .fdp-toolbar { flex-direction: column; align-items: stretch; }
+        .fdp-dep-page .fdp-toolbar-left,
+        .fdp-dep-page .fdp-toolbar-right { width: 100%; }
+        .fdp-dep-page #fdp-dt-search .dataTables_filter label { width: 100%; flex-direction: column; align-items: flex-start; }
+        .fdp-dep-page #fdp-dt-search .dataTables_filter input { width: 100% !important; min-width: 0 !important; }
+        .fdp-dep-page .fdp-chart-wrap { height: 235px; }
+    }
+</style>
+
+<div class="container-fluid fdp-dep-page">
+    <section class="fdp-shell">
+        <div class="fdp-page-header">
+            <div>
+                <h1>Analyse des dépenses projetées</h1>
+                <p class="fdp-muted">
+                    Consultez les dépenses actualisées du fonds de prévoyance par année, groupe Uniformat et catégorie.
+                    Les projections proviennent de l’analyse en vigueur; les dépenses réelles proviennent des tickets fermés de type Fonds de prévoyance.
+                </p>
+            </div>
+
+            <form action="{{ url_for('bp_fonds_prevoyance.depenses_fdp', usager=fdp_usager) }}" method="post" class="form-horizontal" role="form">
+                <label class="fdp-view-toggle" title="Basculer entre la part du syndicat et la part des copropriétaires">
+                    {% if toggle == "syndicat": %}
+                        <input type="checkbox" name="toggle" onchange="this.form.submit()">
+                    {% else %}
+                        <input type="checkbox" name="toggle" onchange="this.form.submit()" checked>
+                    {% endif %}
+                    <span>Vue copropriétaires</span>
+                </label>
+            </form>
+        </div>
+
+        <div class="fdp-kpi-grid">
+            <button type="button" class="fdp-kpi fdp-kpi-total" id="fdp-kpi-total">
+                <span class="fdp-kpi-label">Total projeté — 25 ans</span>
+                <span class="fdp-kpi-value" id="fdp-total-projected">—</span>
+                <span class="fdp-kpi-sub">dépenses visibles</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-next" id="fdp-kpi-next">
+                <span class="fdp-kpi-label">Prochaine dépense</span>
+                <span class="fdp-kpi-value" id="fdp-next-year">—</span>
+                <span class="fdp-kpi-sub" id="fdp-next-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-peak" id="fdp-kpi-peak">
+                <span class="fdp-kpi-label">Année la plus coûteuse</span>
+                <span class="fdp-kpi-value" id="fdp-peak-year">—</span>
+                <span class="fdp-kpi-sub" id="fdp-peak-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-group" id="fdp-kpi-group">
+                <span class="fdp-kpi-label">Groupe principal</span>
+                <span class="fdp-kpi-value" id="fdp-main-group">—</span>
+                <span class="fdp-kpi-sub" id="fdp-main-group-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-count" id="fdp-kpi-count">
+                <span class="fdp-kpi-label">Occurrences projetées</span>
+                <span class="fdp-kpi-value" id="fdp-row-count">—</span>
+                <span class="fdp-kpi-sub">lignes affichées</span>
+            </button>
+        </div>
+
+        <div class="fdp-banner">
+            {% if toggle == "syndicat": %}
+                Analyse courante : dépenses projetées selon la part payée par le syndicat.
+            {% else %}
+                Analyse courante : dépenses projetées selon la part assumée par les copropriétaires.
+            {% endif %}
+        </div>
+
+        {% if fdp_date_warning %}
+        <div class="fdp-warning" role="status">
+            <strong>À vérifier :</strong> {{ fdp_date_warning.replace('À vérifier : ', '') }}
+        </div>
+        {% endif %}
+
+        <div class="fdp-filter-card">
+            <p class="fdp-filter-title">Groupes Uniformat affichés</p>
+            <div class="fdp-chip-row" id="fdp-group-filters">
+                <button type="button" class="fdp-chip active" data-filter-group="all">Tous</button>
+                <button type="button" class="fdp-chip active" data-filter-group="1">A · Infrastructures</button>
+                <button type="button" class="fdp-chip active" data-filter-group="2">B · Superstructures</button>
+                <button type="button" class="fdp-chip active" data-filter-group="3">C · Aménagements</button>
+                <button type="button" class="fdp-chip active" data-filter-group="4">D · Services</button>
+                <button type="button" class="fdp-chip active" data-filter-group="5">E · Équipements</button>
+                <button type="button" class="fdp-chip active" data-filter-group="6">F · Constructions</button>
+                <button type="button" class="fdp-chip active" data-filter-group="7">G · Terrains</button>
+                <button type="button" class="fdp-chip active" data-filter-group="8">Autre</button>
+                <button type="button" class="fdp-chip active" data-filter-group="9">Z · Usage restreint</button>
+            </div>
+        </div>
+
+        <div class="row mb-4">
+            <div class="col-lg-6 col-md-12 mb-4 mb-lg-0">
+                <div class="fdp-card">
+                    <h2>Dépenses projetées par groupe Uniformat</h2>
+                    <p class="fdp-muted">En dollars actualisés. Cliquez une année dans le graphique pour filtrer le calendrier projeté.</p>
+                    <div class="fdp-chart-wrap"><canvas id="fdp-projected-chart"></canvas></div>
+                </div>
+            </div>
+            <div class="col-lg-6 col-md-12">
+                <div class="fdp-card">
+                    <h2>Dépenses réelles vs prévues — 10 ans</h2>
+                    <p class="fdp-muted">Compare les tickets fermés de type Fonds de prévoyance avec les projections de l’analyse active.</p>
+                    <div class="fdp-chart-wrap"><canvas id="fdp-actual-chart"></canvas></div>
+                </div>
+            </div>
+        </div>
+{% if show_projected_table %}
+        <div class="fdp-page-header mb-3">
+            <div>
+                <h1>Calendrier projeté des interventions</h1>
+                <p class="fdp-muted">Liste calculée à partir des interventions du fonds de prévoyance, de leur fréquence et des taux d’inflation applicables.</p>
+            </div>
+        </div>
+
+        <div class="fdp-active-filter" id="fdp-active-filter">
+            <span id="fdp-active-filter-text"></span>
+            <button type="button" class="fdp-clear-filter" id="fdp-clear-year-filter">Effacer le filtre d’année</button>
+        </div>
+
+        <div class="fdp-toolbar">
+            <div class="fdp-toolbar-left"><div id="fdp-dt-buttons"></div></div>
+            <div class="fdp-toolbar-right"><div id="fdp-dt-search"></div></div>
+        </div>
+
+        <div class="fdp-card fdp-table-card" id="fdp-table-card">
+            <div class="fdp-table-scroll-top"><div class="fdp-table-scroll-top-inner"></div></div>
+            <div class="fdp-table-scroll">
+                <table id="table_data" class="table">
+                    <thead>
+                        <tr>
+                            <th>Année</th>
+                            <th>Référence</th>
+                            <th>Type</th>
+                            <th>Groupe</th>
+                            <th>Catégorie</th>
+                            <th>Description</th>
+                            <th>Coût actualisé ($)</th>
+                            <th>Fréquence (ans)</th>
+                            <th>Intervenant</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in fill_table %}
+                        <tr>
+                            <td class="fdp-year">{{ item[4] }}</td>
+                            <td><strong>{{ item[0] }}</strong></td>
+                            <td>
+                                {% if item[5] == "Maintenance" %}
+                                    <span class="fdp-pill fdp-pill-maintenance">Maintenance</span>
+                                {% elif item[5] == "Remplacement" %}
+                                    <span class="fdp-pill fdp-pill-remplacement">Remplacement</span>
+                                {% else %}
+                                    {{ item[5] }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if item[8] %}
+                                    <span class="fdp-pill fdp-pill-group">{{ item[8] }}</span>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>{{ item[6] }}</td>
+                            <td>{{ item[1] }}</td>
+                            <td class="fdp-money">{{ item[3] }}</td>
+                            <td>{{ item[2] }}</td>
+                            <td>{{ item[9] }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+{% endif %}
+    </section>
+</div>
+
+
+<script>
+    function getThemeVar(name, fallback) {
+        const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        return value || fallback;
+    }
+
+    function stripHtml(value) {
+        return $('<div>').html(String(value || '')).text();
+    }
+
+    function normalizeText(value) {
+        return stripHtml(value)
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    function normalizeGroup(value) {
+        return normalizeText(value).replace(/\s*-\s*/g, '-');
+    }
+
+    function formatCurrency(value) {
+        return Number(value || 0).toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' $';
+    }
+
+    function formatCurrencyTooltip(value) {
+        return Number(value || 0).toLocaleString('fr-CA', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        }) + ' $';
+    }
+
+    function formatCurrencyCompact(value) {
+        const num = Number(value || 0);
+
+        if (Math.abs(num) >= 1000000) {
+            return (num / 1000000).toLocaleString('fr-CA', { maximumFractionDigits: 1 }) + ' M$';
+        }
+
+        if (Math.abs(num) >= 1000) {
+            return (num / 1000).toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' k$';
+        }
+
+        return num.toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' $';
+    }
+
+    const chartText = getThemeVar('--theme-text', '#243447');
+    const chartMuted = getThemeVar('--theme-text-muted', '#66778a');
+    const chartBorder = getThemeVar('--theme-border', '#d6dde6');
+
+    const projectedLabels = {{ labels|tojson }};
+    const actualLabels = {{ labels_1|tojson }};
+    const fdpStartYear = {{ fdp_start_year|tojson }};
+    const fdpStartDate = {{ fdp_start_date_label|tojson }};
+    const currentYear = {{ current_year|tojson }};
+    const showProjectedTable = {{ show_projected_table|tojson }};
+
+    const groupDefinitions = [
+        {
+            id: '1',
+            shortLabel: 'A',
+            label: 'Infrastructures',
+            tablePrefix: 'A-',
+            color: getThemeVar('--theme-chart-equipment', '#4a97ab'),
+            projected: {{ values_1|tojson }},
+            comparisonProjected: {{ prev_grp_1|tojson }},
+            actual: {{ dep_grp_1|tojson }}
+        },
+        {
+            id: '2',
+            shortLabel: 'B',
+            label: 'Superstructures et enveloppes',
+            tablePrefix: 'B-',
+            color: getThemeVar('--theme-priority-low', '#198754'),
+            projected: {{ values_2|tojson }},
+            comparisonProjected: {{ prev_grp_2|tojson }},
+            actual: {{ dep_grp_2|tojson }}
+        },
+        {
+            id: '3',
+            shortLabel: 'C',
+            label: 'Aménagements intérieurs',
+            tablePrefix: 'C-',
+            color: getThemeVar('--theme-priority-medium', '#0d6efd'),
+            projected: {{ values_3|tojson }},
+            comparisonProjected: {{ prev_grp_3|tojson }},
+            actual: {{ dep_grp_3|tojson }}
+        },
+        {
+            id: '4',
+            shortLabel: 'D',
+            label: 'Services',
+            tablePrefix: 'D-',
+            color: getThemeVar('--theme-priority-high', '#f4b400'),
+            projected: {{ values_4|tojson }},
+            comparisonProjected: {{ prev_grp_4|tojson }},
+            actual: {{ dep_grp_4|tojson }}
+        },
+        {
+            id: '5',
+            shortLabel: 'E',
+            label: 'Équipements et ameublement',
+            tablePrefix: 'E-',
+            color: getThemeVar('--theme-link-complete', '#f59e0b'),
+            projected: {{ values_5|tojson }},
+            comparisonProjected: {{ prev_grp_5|tojson }},
+            actual: {{ dep_grp_5|tojson }}
+        },
+        {
+            id: '6',
+            shortLabel: 'F',
+            label: 'Constructions spéciales',
+            tablePrefix: 'F-',
+            color: getThemeVar('--theme-priority-critical', '#dc3545'),
+            projected: {{ values_6|tojson }},
+            comparisonProjected: {{ prev_grp_6|tojson }},
+            actual: {{ dep_grp_6|tojson }}
+        },
+        {
+            id: '7',
+            shortLabel: 'G',
+            label: 'Terrains',
+            tablePrefix: 'G-',
+            color: getThemeVar('--theme-link-delete', '#dc3545'),
+            projected: {{ values_7|tojson }},
+            comparisonProjected: {{ prev_grp_7|tojson }},
+            actual: {{ dep_grp_7|tojson }}
+        },
+        {
+            id: '8',
+            shortLabel: 'Autre',
+            label: 'Autre',
+            tablePrefix: 'Autre',
+            color: getThemeVar('--theme-kpi-hours', '#5f788a'),
+            projected: {{ values_8|tojson }},
+            comparisonProjected: {{ prev_grp_8|tojson }},
+            actual: {{ dep_grp_8|tojson }}
+        },
+        {
+            id: '9',
+            shortLabel: 'Z',
+            label: 'Parties communes à usage restreint',
+            tablePrefix: 'Z-',
+            color: getThemeVar('--theme-kpi-age', '#d7dee8'),
+            projected: {{ values_9|tojson }},
+            comparisonProjected: {{ prev_grp_9|tojson }},
+            actual: {{ dep_grp_9|tojson }}
+        }
+    ];
+
+    const projectedRowMetadata = [
+        {% for item in fill_table %}
+        {
+            year: "{{ item[4] }}",
+            groupId: "{{ item[7] }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+    ];
+
+    let activeGroups = new Set(groupDefinitions.map(group => group.id));
+    let activeYearFilter = null;
+    let table = null;
+    let projectedChart = null;
+    let actualChart = null;
+
+    function getVisibleGroups() {
+        return groupDefinitions.filter(group => activeGroups.has(group.id));
+    }
+
+    function getYearTotals() {
+        const visibleGroups = getVisibleGroups();
+
+        return projectedLabels.map((year, index) => {
+            return visibleGroups.reduce((sum, group) => {
+                return sum + Number(group.projected[index] || 0);
+            }, 0);
+        });
+    }
+
+    function getProjected10Totals() {
+        const visibleGroups = getVisibleGroups();
+
+        return actualLabels.map((year, index) => {
+            return visibleGroups.reduce((sum, group) => {
+                return sum + Number(group.comparisonProjected[index] || 0);
+            }, 0);
+        });
+    }
+
+    function tableGroupMatches(groupCell) {
+        if (activeGroups.size === groupDefinitions.length) return true;
+
+        const normalizedCell = normalizeGroup(groupCell);
+
+        return getVisibleGroups().some(group => {
+            const normalizedPrefix = normalizeGroup(group.tablePrefix);
+            const normalizedLabel = normalizeGroup(group.label);
+
+            return normalizedCell.startsWith(normalizedPrefix)
+                || normalizedCell.includes(normalizedLabel)
+                || normalizedCell === normalizedLabel;
+        });
+    }
+
+    function metadataGroupMatches(groupId) {
+        if (activeGroups.size === groupDefinitions.length) return true;
+
+        return activeGroups.has(String(groupId));
+    }
+
+    function setYearFilter(year) {
+        activeYearFilter = year ? String(year) : null;
+        updateActiveFilterBanner();
+
+        if (table) {
+            table.draw();
+            updateKpis();
+
+            const tableCard = document.getElementById('fdp-table-card');
+
+            if (tableCard) {
+                tableCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        } else {
+            updateKpis();
+        }
+    }
+
+    function updateActiveFilterBanner() {
+        const banner = document.getElementById('fdp-active-filter');
+        const text = document.getElementById('fdp-active-filter-text');
+
+        if (!banner || !text) return;
+
+        if (!activeYearFilter) {
+            banner.classList.remove('show');
+            text.textContent = '';
+            return;
+        }
+
+        text.textContent = 'Filtre actif : année ' + activeYearFilter;
+        banner.classList.add('show');
+    }
+
+    function updateGroupChips() {
+        $('[data-filter-group]').each(function () {
+            const groupId = $(this).attr('data-filter-group');
+            const isActive = groupId === 'all'
+                ? activeGroups.size === groupDefinitions.length
+                : activeGroups.has(groupId);
+
+            $(this).toggleClass('active', isActive);
+        });
+    }
+
+    function updateCharts() {
+        if (projectedChart) {
+            projectedChart.data.datasets.forEach(dataset => {
+                dataset.hidden = dataset.groupId && !activeGroups.has(dataset.groupId);
+            });
+
+            projectedChart.update();
+        }
+
+        if (actualChart) {
+            actualChart.data.datasets.forEach(dataset => {
+                if (dataset.groupId) {
+                    dataset.hidden = !activeGroups.has(dataset.groupId);
+                }
+
+                if (dataset.datasetRole === 'projected-line') {
+                    dataset.data = getProjected10Totals();
+                }
+            });
+
+            actualChart.update();
+        }
+    }
+
+    function getRowCountForYear(year) {
+        if (table) {
+            let count = 0;
+
+            table.rows().every(function () {
+                const data = this.data();
+
+                if (String(stripHtml(data[0])) === String(year) && tableGroupMatches(data[3])) {
+                    count += 1;
+                }
+            });
+
+            return count;
+        }
+
+        return projectedRowMetadata.filter(row => {
+            return String(row.year) === String(year) && metadataGroupMatches(row.groupId);
+        }).length;
+    }
+
+    function getVisibleProjectedRowCount() {
+        if (table) {
+            return table.rows({ search: 'applied' }).data().length;
+        }
+
+        return projectedRowMetadata.filter(row => {
+            const yearMatches = !activeYearFilter || String(row.year) === String(activeYearFilter);
+            const groupMatches = metadataGroupMatches(row.groupId);
+
+            return yearMatches && groupMatches;
+        }).length;
+    }
+
+    function updateKpis() {
+        const totals = getYearTotals();
+        const total = totals.reduce((sum, value) => sum + Number(value || 0), 0);
+        const firstIndex = totals.findIndex(value => Number(value || 0) > 0);
+        const peakValue = Math.max.apply(null, totals.concat([0]));
+        const peakIndex = totals.findIndex(value => Number(value || 0) === peakValue && peakValue > 0);
+
+        let mainGroup = null;
+        let mainGroupValue = 0;
+
+        getVisibleGroups().forEach(group => {
+            const value = group.projected.reduce((sum, current) => sum + Number(current || 0), 0);
+
+            if (value > mainGroupValue) {
+                mainGroup = group;
+                mainGroupValue = value;
+            }
+        });
+
+        $('#fdp-total-projected').text(formatCurrency(total));
+
+        if (firstIndex >= 0) {
+            const year = projectedLabels[firstIndex];
+            const count = getRowCountForYear(year);
+
+            $('#fdp-next-year').text(year);
+            $('#fdp-next-sub').text(count + ' intervention' + (count > 1 ? 's' : '') + ' · ' + formatCurrency(totals[firstIndex]));
+            $('#fdp-kpi-next').attr('data-year', year);
+        } else {
+            $('#fdp-next-year').text('—');
+            $('#fdp-next-sub').text('aucune dépense visible');
+            $('#fdp-kpi-next').removeAttr('data-year');
+        }
+
+        if (peakIndex >= 0) {
+            const year = projectedLabels[peakIndex];
+
+            $('#fdp-peak-year').text(year);
+            $('#fdp-peak-sub').text(formatCurrency(peakValue));
+            $('#fdp-kpi-peak').attr('data-year', year);
+        } else {
+            $('#fdp-peak-year').text('—');
+            $('#fdp-peak-sub').text('aucune dépense visible');
+            $('#fdp-kpi-peak').removeAttr('data-year');
+        }
+
+        if (mainGroup) {
+            $('#fdp-main-group').text(mainGroup.shortLabel + ' · ' + mainGroup.label);
+            $('#fdp-main-group-sub').text(formatCurrency(mainGroupValue));
+            $('#fdp-kpi-group').attr('data-group', mainGroup.id);
+        } else {
+            $('#fdp-main-group').text('—');
+            $('#fdp-main-group-sub').text('aucun groupe visible');
+            $('#fdp-kpi-group').removeAttr('data-group');
+        }
+
+        $('#fdp-row-count').text(getVisibleProjectedRowCount().toLocaleString('fr-CA'));
+    }
+
+    function syncFdpScrollWidth() {
+        const bottom = $('.fdp-table-scroll').get(0);
+
+        if (!bottom) return;
+
+        $('.fdp-table-scroll-top-inner').width(bottom.scrollWidth);
+        $('.fdp-table-scroll-top').scrollLeft($('.fdp-table-scroll').scrollLeft());
+
+        if (table) {
+            table.columns.adjust();
+        }
+    }
+
+    const fdpMarkerPlugin = {
+        afterDraw: function (chart) {
+            const markers = chart.config.options.fdpMarkers || [];
+
+            if (!markers.length) return;
+
+            const xAxis = chart.scales['x-axis-0'];
+            const chartArea = chart.chartArea;
+            const ctx = chart.chart.ctx;
+
+            if (!xAxis || !chartArea) return;
+
+            chart.fdpMarkerHitboxes = [];
+
+            markers.forEach(function (marker, markerIndex) {
+                const index = chart.data.labels.findIndex(label => String(label) === String(marker.year));
+
+                if (index === -1) return;
+
+                const x = xAxis.getPixelForTick(index);
+                const label = marker.label;
+
+                ctx.save();
+
+                ctx.beginPath();
+                ctx.setLineDash([5, 5]);
+                ctx.moveTo(x, chartArea.top);
+                ctx.lineTo(x, chartArea.bottom);
+                ctx.lineWidth = 2;
+                ctx.strokeStyle = marker.color;
+                ctx.stroke();
+
+                ctx.setLineDash([]);
+                ctx.font = 'bold 11px "Segoe UI", Arial, sans-serif';
+
+                const textWidth = ctx.measureText(label).width;
+                const boxWidth = textWidth + 12;
+                const boxHeight = 18;
+                const boxX = Math.min(
+                    Math.max(x - boxWidth / 2, chartArea.left),
+                    chartArea.right - boxWidth
+                );
+                const boxY = chartArea.top + 4 + (markerIndex * 22);
+
+                chart.fdpMarkerHitboxes.push({
+                    left: boxX,
+                    right: boxX + boxWidth,
+                    top: chartArea.top,
+                    bottom: chartArea.bottom,
+                    tooltip: marker.tooltip || marker.label
+                });
+
+                ctx.fillStyle = marker.color;
+                ctx.fillRect(boxX, boxY, boxWidth, boxHeight);
+
+                ctx.fillStyle = '#fff';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(label, boxX + 6, boxY + boxHeight / 2);
+
+                ctx.restore();
+            });
+        }
+    };
+
+    Chart.plugins.register(fdpMarkerPlugin);
+
+    function attachMarkerHover(chart, canvas) {
+        if (!chart || !canvas) return;
+
+        canvas.addEventListener('mousemove', function (event) {
+            const rect = canvas.getBoundingClientRect();
+            const x = event.clientX - rect.left;
+            const y = event.clientY - rect.top;
+
+            const hit = (chart.fdpMarkerHitboxes || []).find(marker => {
+                return x >= marker.left
+                    && x <= marker.right
+                    && y >= marker.top
+                    && y <= marker.bottom;
+            });
+
+            canvas.style.cursor = hit ? 'help' : 'default';
+            canvas.title = hit ? hit.tooltip : '';
+        });
+
+        canvas.addEventListener('mouseleave', function () {
+            canvas.style.cursor = 'default';
+            canvas.title = '';
+        });
+    }
+
+    function createCharts() {
+        Chart.defaults.global.defaultFontColor = chartText;
+
+        projectedChart = new Chart(document.getElementById('fdp-projected-chart'), {
+            type: 'bar',
+            data: {
+                labels: projectedLabels,
+                datasets: groupDefinitions.map(group => ({
+                    label: group.shortLabel + ' · ' + group.label,
+                    groupId: group.id,
+                    backgroundColor: group.color,
+                    borderColor: group.color,
+                    data: group.projected,
+                    borderWidth: 0
+                }))
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: { display: false },
+                tooltips: {
+                    callbacks: {
+                        label: function (tooltipItem, data) {
+                            const dataset = data.datasets[tooltipItem.datasetIndex];
+                            const total = data.datasets.reduce((sum, current) => {
+                                return current.hidden ? sum : sum + Number(current.data[tooltipItem.index] || 0);
+                            }, 0);
+
+                            return [
+                                dataset.label + ' : ' + formatCurrencyTooltip(tooltipItem.yLabel || 0),
+                                'Total de l’année : ' + formatCurrencyTooltip(total)
+                            ];
+                        }
+                    }
+                },
+                onClick: function (event) {
+                    const points = this.getElementAtEvent(event);
+
+                    if (points.length) {
+                        setYearFilter(projectedLabels[points[0]._index]);
+                    }
+                },
+                scales: {
+                    xAxes: [{
+                        stacked: true,
+                        gridLines: { color: chartBorder },
+                        ticks: { fontColor: chartMuted }
+                    }],
+                    yAxes: [{
+                        stacked: true,
+                        gridLines: { color: chartBorder },
+                        ticks: {
+                            beginAtZero: true,
+                            fontColor: chartMuted,
+                            callback: formatCurrencyCompact
+                        }
+                    }]
+                }
+            }
+        });
+
+        actualChart = new Chart(document.getElementById('fdp-actual-chart'), {
+            type: 'bar',
+            data: {
+                labels: actualLabels,
+                datasets: [{
+                    label: 'Dépenses prévues',
+                    datasetRole: 'projected-line',
+                    type: 'line',
+                    data: getProjected10Totals(),
+                    borderColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    backgroundColor: 'rgba(13, 110, 253, 0.10)',
+                    pointBackgroundColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    pointBorderColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    pointRadius: 4,
+                    pointHoverRadius: 5,
+                    borderWidth: 3,
+                    fill: true,
+                    lineTension: 0.25
+                }].concat(groupDefinitions.map(group => ({
+                    label: 'Réel — ' + group.shortLabel + ' · ' + group.label,
+                    groupId: group.id,
+                    backgroundColor: group.color,
+                    borderColor: group.color,
+                    data: group.actual,
+                    borderWidth: 0
+                })))
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: { display: false },
+                fdpMarkers: [
+                    {
+                        year: fdpStartYear,
+                        label: 'Début FDP',
+                        tooltip: 'Début FDP : ' + fdpStartDate,
+                        color: getThemeVar('--theme-link-complete', '#f59e0b')
+                    },
+                    {
+                        year: currentYear,
+                        label: 'Année courante',
+                        tooltip: 'Année courante : ' + currentYear,
+                        color: getThemeVar('--theme-link-edit', '#0d6efd')
+                    }
+                ],
+                tooltips: {
+                    callbacks: {
+                        label: function (tooltipItem, data) {
+                            const dataset = data.datasets[tooltipItem.datasetIndex];
+                            const prefix = dataset.datasetRole === 'projected-line'
+                                ? 'Dépenses prévues : '
+                                : dataset.label + ' : ';
+
+                            return prefix + formatCurrencyTooltip(tooltipItem.yLabel || 0);
+                        }
+                    }
+                },
+                scales: {
+                    xAxes: [{
+                        stacked: true,
+                        gridLines: { color: chartBorder },
+                        ticks: { fontColor: chartMuted }
+                    }],
+                    yAxes: [{
+                        stacked: true,
+                        gridLines: { color: chartBorder },
+                        ticks: {
+                            beginAtZero: true,
+                            fontColor: chartMuted,
+                            callback: formatCurrencyCompact
+                        }
+                    }]
+                }
+            }
+        });
+
+        attachMarkerHover(actualChart, document.getElementById('fdp-actual-chart'));
+    }
+
+    function initializeDataTable() {
+        if (!showProjectedTable || !$('#table_data').length) return;
+
+        $.fn.dataTable.ext.search.push(function (settings, data) {
+            if (settings.nTable.id !== 'table_data') return true;
+
+            const rowYear = String(stripHtml(data[0] || ''));
+
+            if (activeYearFilter && rowYear !== String(activeYearFilter)) {
+                return false;
+            }
+
+            return tableGroupMatches(data[3]);
+        });
+
+        table = $('#table_data').DataTable({
+            dom: 'Blfrtip',
+            lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'Tous']],
+            pageLength: 25,
+            order: [[0, 'asc']],
+            buttons: [{
+                extend: 'excelHtml5',
+                title: 'Export CondoFix Dépenses Prévues Fonds de Prévoyance',
+                text: 'Excel'
+            }],
+            language: {
+                decimal: '',
+                emptyTable: 'Aucune donnée disponible dans le tableau',
+                info: 'Affichage de _START_ à _END_ sur _TOTAL_ entrées',
+                infoEmpty: 'Affichage de 0 à 0 sur 0 entrée',
+                infoFiltered: '(filtré à partir de _MAX_ entrées au total)',
+                thousands: ' ',
+                lengthMenu: 'Afficher _MENU_ entrées',
+                loadingRecords: 'Chargement...',
+                processing: 'Traitement...',
+                search: 'Recherche',
+                zeroRecords: 'Aucun résultat trouvé',
+                paginate: {
+                    first: 'Premier',
+                    last: 'Dernier',
+                    next: 'Suivant',
+                    previous: 'Précédent'
+                },
+                aria: {
+                    sortAscending: ': activer pour trier la colonne par ordre croissant',
+                    sortDescending: ': activer pour trier la colonne par ordre décroissant'
+                }
+            },
+            initComplete: function () {
+                const wrapper = $('#table_data_wrapper');
+
+                wrapper.find('.dt-buttons').appendTo('#fdp-dt-buttons');
+                wrapper.find('.dataTables_filter').appendTo('#fdp-dt-search');
+
+                syncFdpScrollWidth();
+            }
+        });
+
+        table.on('draw', function () {
+            updateKpis();
+            syncFdpScrollWidth();
+        });
+
+        $('#fdp-clear-year-filter').on('click', function () {
+            setYearFilter(null);
+        });
+
+        $('.fdp-table-scroll-top').on('scroll', function () {
+            $('.fdp-table-scroll').scrollLeft($(this).scrollLeft());
+        });
+
+        $('.fdp-table-scroll').on('scroll', function () {
+            $('.fdp-table-scroll-top').scrollLeft($(this).scrollLeft());
+        });
+
+        $(window).on('resize', syncFdpScrollWidth);
+        setTimeout(syncFdpScrollWidth, 150);
+        syncFdpScrollWidth();
+    }
+
+    function bindInteractions() {
+        $('#fdp-group-filters').on('click', '[data-filter-group]', function () {
+            const groupId = $(this).attr('data-filter-group');
+
+            if (groupId === 'all') {
+                activeGroups = new Set(groupDefinitions.map(group => group.id));
+            } else if (activeGroups.size === groupDefinitions.length) {
+                activeGroups = new Set([groupId]);
+            } else if (activeGroups.has(groupId)) {
+                activeGroups.delete(groupId);
+
+                if (activeGroups.size === 0) {
+                    activeGroups = new Set(groupDefinitions.map(group => group.id));
+                }
+            } else {
+                activeGroups.add(groupId);
+            }
+
+            updateGroupChips();
+            updateCharts();
+
+            if (table) {
+                table.draw();
+            }
+
+            updateKpis();
+        });
+
+        $('#fdp-kpi-total, #fdp-kpi-count').on('click', function () {
+            activeYearFilter = null;
+            activeGroups = new Set(groupDefinitions.map(group => group.id));
+
+            updateGroupChips();
+            updateCharts();
+            updateActiveFilterBanner();
+
+            if (table) {
+                table.draw();
+            }
+
+            updateKpis();
+        });
+
+        $('#fdp-kpi-next, #fdp-kpi-peak').on('click', function () {
+            const year = $(this).attr('data-year');
+
+            if (year) {
+                setYearFilter(year);
+            }
+        });
+
+        $('#fdp-kpi-group').on('click', function () {
+            const groupId = $(this).attr('data-group');
+
+            if (!groupId) return;
+
+            activeGroups = new Set([groupId]);
+            activeYearFilter = null;
+
+            updateGroupChips();
+            updateCharts();
+            updateActiveFilterBanner();
+
+            if (table) {
+                table.draw();
+            }
+
+            updateKpis();
+        });
+    }
+
+    $(document).ready(function () {
+        createCharts();
+        initializeDataTable();
+        bindInteractions();
+        updateGroupChips();
+        updateKpis();
+        syncFdpScrollWidth();
+    });
+</script>
+
+{% endblock content %}

--- a/mysite_PA_july11/condofix/templates/graph_fdp_dep_admin.html
+++ b/mysite_PA_july11/condofix/templates/graph_fdp_dep_admin.html
@@ -876,7 +876,7 @@
                 const wrapper = $('#table_data_wrapper');
                 wrapper.find('.dt-buttons').appendTo('#fdp-dt-buttons');
                 wrapper.find('.dataTables_filter').appendTo('#fdp-dt-search');
-                updateKpis();
+
                 syncFdpScrollWidth();
             }
         });
@@ -885,6 +885,14 @@
             updateKpis();
             syncFdpScrollWidth();
         });
+
+        /*
+         * Initial KPI refresh.
+         * Must run after the DataTable assignment above, otherwise updateKpis()
+         * can read the table before the DataTables API is available.
+         */
+        updateKpis();
+        syncFdpScrollWidth();
 
         $('#fdp-group-filters').on('click', '[data-filter-group]', function () {
             const groupId = $(this).attr('data-filter-group');

--- a/mysite_PA_july11/condofix/templates/graph_fdp_dep_admin.html
+++ b/mysite_PA_july11/condofix/templates/graph_fdp_dep_admin.html
@@ -1,338 +1,943 @@
 {% extends "layout_admin_tables.html" %}
 {% block content %}
 
-<head xmlns="http://www.w3.org/1999/html">
-    <title>CondoFix</title>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="../static/ToolsIcon.png">
-    <!-- javascript ne peut pas lire un fichier sur une machine locale donc on DOIT utiliser le plugin de 'datatables'-->
-    <script src="../static/DataTables/DataTables_with_buttons/jquery-3.5.1.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/jquery.dataTables.min.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/dataTables.buttons.min.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/jszip.min.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/pdfmake.min.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/vfs_fonts.js"></script>
-    <script src="../static/DataTables/DataTables_with_buttons/buttons.html5.min.js"></script>
-    <!-- pour que les menus dropdown fonctionnent avec DataTables-->
-    <script src="../static/bootstrap-4.1.3-dist/js/bootstrap.min.js"></script>
+<!-- DataTables -->
+<script src="../static/DataTables/DataTables_with_buttons/jquery-3.5.1.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/jquery.dataTables.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/dataTables.buttons.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/jszip.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/pdfmake.min.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/vfs_fonts.js"></script>
+<script src="../static/DataTables/DataTables_with_buttons/buttons.html5.min.js"></script>
 
-    <!-- pour le style de la table-->
-    <link href="../static/DataTables/DataTables_with_buttons/css/jquery.dataTables.min.css" rel="stylesheet" />
-    <link href="../static/DataTables/DataTables_with_buttons/css/buttons.dataTables.min.css" rel="stylesheet" />
-    <script src="../static/Chart.min.js"></script>
-    <script>
-    $(document).ready(function() {
-        $('#table_data').DataTable({
-        dom: 'Bfrtip',
-        buttons: [
-             {
-               extend: 'excelHtml5',
-               title: 'Export CondoFix Dépenses Prévues Fonds de Prévoyance'
+<!-- Bootstrap JS -->
+<script src="../static/bootstrap-4.1.3-dist/js/bootstrap.min.js"></script>
 
-            }
-        ],
-        "order": [[ 7, "asc" ]],
-        "pageLength":100,
-        language: {
-                url: "//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/French.json"
-            }
-        });
-    } );
-    </script>
+<!-- Chart.js -->
+<script src="../static/Chart.min.js"></script>
 
-</head>
-<body>
+<!-- DataTables CSS -->
+<link href="../static/DataTables/DataTables_with_buttons/css/jquery.dataTables.min.css" rel="stylesheet" />
+<link href="../static/DataTables/DataTables_with_buttons/css/buttons.dataTables.min.css" rel="stylesheet" />
+
 <style>
-    h4 {
-  margin: 1px;
-}
-p {
- display: inline-block;
- vertical-align: middle;
- padding-top: 5px;
- padding-right:5px;
-}
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 60px;
-  height: 34px;
-}
+    .fdp-dep-page {
+        --fdp-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+        --fdp-soft-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+        --fdp-radius-xl: 20px;
+        --fdp-radius-lg: 16px;
+        --fdp-radius-md: 14px;
+        --fdp-radius-sm: 12px;
+        color: var(--theme-text);
+        padding: 1.25rem 0 2rem;
+    }
 
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
+    .fdp-dep-page .fdp-shell,
+    .fdp-dep-page .fdp-card {
+        background: var(--theme-surface);
+        border: 1px solid var(--theme-border);
+        box-shadow: var(--fdp-shadow);
+    }
 
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
-}
+    .fdp-dep-page .fdp-shell {
+        border-radius: var(--fdp-radius-xl);
+        padding: 1.25rem;
+    }
 
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
-}
+    .fdp-dep-page .fdp-card {
+        border-radius: var(--fdp-radius-lg);
+        padding: 1rem;
+        height: 100%;
+    }
 
-input:checked + .slider {
-  background-color: #2196F3;
-}
+    .fdp-dep-page .fdp-page-header,
+    .fdp-dep-page .fdp-toolbar {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
 
-input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
-}
+    .fdp-dep-page h1 {
+        margin: 0;
+        color: var(--theme-text);
+        font-size: 1.95rem;
+        font-weight: 800;
+        line-height: 1.1;
+    }
 
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
+    .fdp-dep-page h2 {
+        margin: 0 0 0.35rem;
+        color: var(--theme-text);
+        font-size: 1.2rem;
+        font-weight: 800;
+    }
 
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
-}
+    .fdp-dep-page .fdp-muted {
+        margin: 0.35rem 0 0;
+        color: var(--theme-text-muted);
+        font-size: 0.98rem;
+    }
 
-.slider.round:before {
-  border-radius: 50%;
-}
+    .fdp-dep-page .fdp-view-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        min-height: 44px;
+        padding: 0.55rem 0.85rem;
+        border: 1px solid var(--theme-border);
+        border-radius: var(--fdp-radius-md);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+        cursor: pointer;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page .fdp-view-toggle input {
+        width: 16px;
+        height: 16px;
+        margin: 0;
+        accent-color: var(--theme-link-edit);
+    }
+
+    .fdp-dep-page .fdp-kpi-grid {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(150px, 1fr));
+        gap: 0.75rem;
+        margin: 1rem 0;
+    }
+
+    .fdp-dep-page .fdp-kpi {
+        min-height: 88px;
+        padding: 0.85rem 1rem;
+        border: 0;
+        border-radius: var(--fdp-radius-lg);
+        color: #fff;
+        box-shadow: var(--fdp-soft-shadow);
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    }
+
+    .fdp-dep-page .fdp-kpi:hover,
+    .fdp-dep-page .fdp-kpi:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 22px rgba(15, 23, 42, 0.14);
+        outline: none;
+    }
+
+    .fdp-dep-page .fdp-kpi-label {
+        display: block;
+        font-size: 0.72rem;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.035em;
+    }
+
+    .fdp-dep-page .fdp-kpi-value {
+        display: block;
+        margin-top: 0.25rem;
+        font-size: 1.45rem;
+        font-weight: 900;
+        line-height: 1.05;
+    }
+
+    .fdp-dep-page .fdp-kpi-sub {
+        display: block;
+        margin-top: 0.25rem;
+        font-size: 0.78rem;
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-kpi-total { background: linear-gradient(135deg, var(--theme-priority-medium), var(--theme-link-edit)); color: var(--theme-priority-medium-text); }
+    .fdp-dep-page .fdp-kpi-next { background: linear-gradient(135deg, var(--theme-priority-high), var(--theme-link-complete)); color: var(--theme-priority-high-text); }
+    .fdp-dep-page .fdp-kpi-peak { background: linear-gradient(135deg, var(--theme-priority-critical), var(--theme-link-delete)); color: var(--theme-priority-critical-text); }
+    .fdp-dep-page .fdp-kpi-group { background: linear-gradient(135deg, var(--theme-priority-low), var(--theme-chart-equipment)); color: var(--theme-priority-low-text); }
+    .fdp-dep-page .fdp-kpi-count { background: linear-gradient(135deg, var(--theme-kpi-hours), var(--theme-chart-budget)); color: var(--theme-kpi-hours-text); }
+
+    .fdp-dep-page .fdp-banner,
+    .fdp-dep-page .fdp-active-filter {
+        padding: 0.85rem 1rem;
+        border-radius: var(--fdp-radius-md);
+        border: 1px dashed var(--theme-border);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+    }
+
+    .fdp-dep-page .fdp-banner { margin-bottom: 1rem; }
+
+    .fdp-dep-page .fdp-filter-card {
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border-radius: var(--fdp-radius-lg);
+        border: 1px solid var(--theme-border);
+        background: var(--theme-surface);
+        box-shadow: var(--fdp-soft-shadow);
+    }
+
+    .fdp-dep-page .fdp-filter-title {
+        margin: 0 0 0.75rem;
+        color: var(--theme-text);
+        font-weight: 900;
+    }
+
+    .fdp-dep-page .fdp-chip-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .fdp-dep-page .fdp-chip {
+        min-height: 34px;
+        padding: 0.4rem 0.72rem;
+        border-radius: 999px;
+        border: 1px solid var(--theme-border);
+        background: var(--theme-surface-alt);
+        color: var(--theme-text);
+        font-weight: 800;
+        font-size: 0.84rem;
+        cursor: pointer;
+        transition: all 0.15s ease-in-out;
+    }
+
+    .fdp-dep-page .fdp-chip:hover,
+    .fdp-dep-page .fdp-chip:focus {
+        transform: translateY(-1px);
+        box-shadow: var(--fdp-soft-shadow);
+        outline: none;
+    }
+
+    .fdp-dep-page .fdp-chip.active {
+        background: var(--theme-link-edit);
+        border-color: var(--theme-link-edit);
+        color: #fff;
+    }
+
+    .fdp-dep-page .fdp-chart-wrap {
+        position: relative;
+        width: 100%;
+        height: 305px;
+    }
+
+    .fdp-dep-page .fdp-chart-wrap canvas {
+        display: block !important;
+        width: 100% !important;
+        height: 100% !important;
+    }
+
+    .fdp-dep-page .fdp-table-card {
+        border-radius: var(--fdp-radius-lg);
+        overflow: hidden;
+    }
+
+    .fdp-dep-page .fdp-table-scroll-top,
+    .fdp-dep-page .fdp-table-scroll {
+        width: 100%;
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .fdp-dep-page .fdp-table-scroll-top { height: 18px; margin-bottom: 8px; }
+    .fdp-dep-page .fdp-table-scroll-top-inner { height: 1px; min-width: 1250px; }
+    .fdp-dep-page .fdp-table-scroll table { min-width: 1250px !important; }
+
+    .fdp-dep-page .fdp-toolbar { align-items: center; margin: 0.5rem 0 1rem; }
+    .fdp-dep-page .fdp-toolbar-left,
+    .fdp-dep-page .fdp-toolbar-right { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+
+    .fdp-dep-page .dt-buttons .dt-button {
+        min-height: 42px;
+        padding: 0.6rem 1rem;
+        border-radius: var(--fdp-radius-sm);
+        border: 1px solid var(--theme-border) !important;
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        font-weight: 800 !important;
+        box-shadow: none !important;
+        margin: 0 !important;
+    }
+
+    .fdp-dep-page #fdp-dt-search .dataTables_filter label,
+    .fdp-dep-page .dataTables_wrapper .dataTables_filter label {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+        margin: 0;
+        color: var(--theme-text-muted);
+        font-weight: 800;
+    }
+
+    .fdp-dep-page #fdp-dt-search .dataTables_filter input,
+    .fdp-dep-page .dataTables_wrapper .dataTables_filter input {
+        margin-left: 0 !important;
+        width: 260px !important;
+        min-height: 44px !important;
+        padding: 0.65rem 0.95rem !important;
+        border-radius: 14px !important;
+        border: 1px solid var(--theme-border) !important;
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        outline: none !important;
+        box-shadow: none !important;
+    }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_length,
+    .fdp-dep-page .dataTables_wrapper .dataTables_info,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate { color: var(--theme-text-muted) !important; }
+
+    .fdp-dep-page table.dataTable,
+    .fdp-dep-page table#table_data {
+        width: 100% !important;
+        margin: 0 !important;
+        border-collapse: separate !important;
+        border-spacing: 0 !important;
+        font-family: Inter, "Segoe UI", Arial, sans-serif;
+        font-size: 0.94rem;
+        border: 0 !important;
+    }
+
+    .fdp-dep-page table.dataTable thead th,
+    .fdp-dep-page table#table_data thead th {
+        background: var(--theme-surface-alt) !important;
+        color: var(--theme-text) !important;
+        border-bottom: 1px solid var(--theme-border) !important;
+        border-right: 0 !important;
+        padding: 14px 26px 14px 12px !important;
+        font-size: 0.9rem;
+        font-weight: 900;
+        vertical-align: middle;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page table.dataTable tbody td,
+    .fdp-dep-page table#table_data tbody td {
+        background: var(--theme-surface) !important;
+        color: var(--theme-text) !important;
+        border-top: 0 !important;
+        border-right: 0 !important;
+        border-left: 0 !important;
+        border-bottom: 1px solid var(--theme-border) !important;
+        padding: 14px 12px !important;
+        vertical-align: top;
+    }
+
+    .fdp-dep-page table.dataTable tbody tr:nth-child(even) td,
+    .fdp-dep-page table#table_data tbody tr:nth-child(even) td { background: rgba(127, 145, 168, 0.05) !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_length { padding: 1rem 0.5rem 0.75rem !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_info { padding: 1.2rem 0.5rem 0.6rem !important; }
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate { padding: 1rem 0.5rem 0.75rem !important; }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button {
+        border-radius: 10px !important;
+        border: 1px solid transparent !important;
+        color: var(--theme-text) !important;
+        padding: 0.45rem 0.8rem !important;
+        margin-left: 0.2rem !important;
+    }
+
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button.current,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover,
+    .fdp-dep-page .dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+        background: var(--theme-surface-alt) !important;
+        border-color: var(--theme-border) !important;
+        color: var(--theme-text) !important;
+    }
+
+    .fdp-dep-page .fdp-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 24px;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.78rem;
+        font-weight: 900;
+        line-height: 1.1;
+        white-space: nowrap;
+    }
+
+    .fdp-dep-page .fdp-pill-maintenance { color: var(--theme-link-edit); background: rgba(13, 110, 253, 0.12); }
+    .fdp-dep-page .fdp-pill-remplacement { color: var(--theme-link-complete); background: rgba(245, 158, 11, 0.14); }
+    .fdp-dep-page .fdp-pill-group { color: var(--theme-text); background: var(--theme-surface-alt); border: 1px solid var(--theme-border); }
+    .fdp-dep-page .fdp-money,
+    .fdp-dep-page .fdp-year { font-weight: 900; white-space: nowrap; }
+
+    .fdp-dep-page .fdp-active-filter { display: none; margin-bottom: 0.9rem; }
+    .fdp-dep-page .fdp-active-filter.show { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
+    .fdp-dep-page .fdp-clear-filter { border: 0; background: transparent; color: var(--theme-link-edit); font-weight: 900; cursor: pointer; padding: 0; }
+
+    @media (max-width: 1200px) { .fdp-dep-page .fdp-kpi-grid { grid-template-columns: repeat(3, minmax(150px, 1fr)); } }
+    @media (max-width: 991px) { .fdp-dep-page .fdp-chart-wrap { height: 270px; } }
+    @media (max-width: 768px) {
+        .fdp-dep-page .fdp-shell { padding: 1rem; border-radius: 16px; }
+        .fdp-dep-page h1 { font-size: 1.6rem; }
+        .fdp-dep-page .fdp-kpi-grid { grid-template-columns: repeat(2, minmax(140px, 1fr)); }
+    }
+    @media (max-width: 575px) {
+        .fdp-dep-page .fdp-kpi-grid { grid-template-columns: 1fr; }
+        .fdp-dep-page .fdp-toolbar { flex-direction: column; align-items: stretch; }
+        .fdp-dep-page .fdp-toolbar-left,
+        .fdp-dep-page .fdp-toolbar-right { width: 100%; }
+        .fdp-dep-page #fdp-dt-search .dataTables_filter label { width: 100%; flex-direction: column; align-items: flex-start; }
+        .fdp-dep-page #fdp-dt-search .dataTables_filter input { width: 100% !important; min-width: 0 !important; }
+        .fdp-dep-page .fdp-chart-wrap { height: 235px; }
+    }
 </style>
-<form action="{{ url_for('bp_fonds_prevoyance.depenses_fdp',usager='admin') }}" method=post class="form-horizontal" role="form">
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-sm-6">
-            <div class="wrapper">
-                <h4>Dépenses prévues par groupe Uniformat II</h4>
-                <p><small>En $ actualisés. Survol avec souris pour détail des interventions. Interventions affichées au tableau.</small></p>
-                <canvas id="bar-chart" width="500" height="325"></canvas>
+
+<div class="container-fluid fdp-dep-page">
+    <section class="fdp-shell">
+        <div class="fdp-page-header">
+            <div>
+                <h1>Analyse des dépenses projetées</h1>
+                <p class="fdp-muted">
+                    Consultez les dépenses actualisées du fonds de prévoyance par année, groupe Uniformat et catégorie.
+                    Les projections proviennent de l’analyse en vigueur; les dépenses réelles proviennent des tickets fermés de type Fonds de prévoyance.
+                </p>
             </div>
-            <script>
 
-              new Chart(document.getElementById("bar-chart"), {
-                  type: 'bar',
-                  data: {
-                    labels: {{labels|tojson}},
-                    datasets: [
-                      {
-                      label: 'Infrastructures',
-                      type: 'bar',
-                      backgroundColor: "#caf270",
-                      data: {{ values_1|tojson }},
-                    }, {
-                      label: 'Superstructures et enveloppes',
-                      backgroundColor: "#45c490",
-                      data: {{ values_2|tojson }},
-                    }, {
-                      label: 'Aménagements intérieurs',
-                      backgroundColor: "#008d93",
-                      data: {{ values_3|tojson }},
-                    }, {
-                      label: 'Services',
-                      backgroundColor: "#F8C471",
-                      data: {{ values_4|tojson }},
-                    }, {
-                      label: 'Équipements et ameublement',
-                      backgroundColor: "#D35400",
-                      data: {{ values_5|tojson }},
-                    }, {
-                      label: 'Constructions spéciales',
-                      backgroundColor: "#EC7063",
-                      data: {{ values_6|tojson }},
-                    }, {
-                      label: 'Terrain',
-                      backgroundColor: "#E6B0AA",
-                      data: {{ values_7|tojson }},
-                    }, {
-                      label: 'Autre',
-                      backgroundColor: "#B2BEB5",
-                      data: {{ values_8|tojson }},
-                    }, {
-                      label: 'Parties communes usage restreint',
-                      backgroundColor: "#bad80a",
-                      data: {{ values_9|tojson }},
-                    }
-                    ]
-                  },
-                  options: {
-                    legend: { display: false },
-                    title: {
-                      display: false,
-                      text: 'blabla'
-                    },
-                    scales: {
-                    xAxes: [{ stacked: true }],
-                    yAxes: [{ stacked: true }]
-                    },
-                    responsive: false
-                  }
-                  });
-            </script>
-        </div>
-        <div class="col-sm-6">
-            <div class="wrapper">
-                <h4>Dépenses actuelles et prévues sur 10 ans</h4>
-                <p><small>En $ actualisés. Depuis dernière analyse de fonds de prévoyance. Détail avec survol de souris.</small></p>
-                <canvas id="hybrid-chart" width="500" height="325"></canvas>
-            </div>
-            <script>
-              //console.log({{labels_1|tojson}});
-              //console.log({{dep_grp_1|tojson}});
-              new Chart(document.getElementById("hybrid-chart"), {
-                  type: 'bar',
-                  data: {
-                    labels: {{labels_1|tojson}},
-                    datasets: [
-                      {
-                       label: 'Dépenses prévues',
-                       borderColor: "#1F618D",
-                       data: {{ dep_prevues|tojson }},
-                       type: 'line',
-                     }, {
-                      label: 'Infrastructures',
-                      backgroundColor: "#caf270",
-                      data: {{ dep_grp_1|tojson }},
-                      type: 'bar',
-                    }, {
-                      label: 'Superstructures et enveloppes',
-                      backgroundColor: "#45c490",
-                      data: {{ dep_grp_2|tojson }},
-
-                    }, {
-                      label: 'Aménagements intérieurs',
-                      backgroundColor: "#008d93",
-                      data: {{ dep_grp_3|tojson }},
-
-                    }, {
-                      label: 'Services',
-                      backgroundColor: "#F8C471",
-                      data: {{ dep_grp_4|tojson }},
-
-                    }, {
-                      label: 'Équipements et ameublement',
-                      backgroundColor: "#D35400",
-                      data: {{ dep_grp_5|tojson }},
-
-                    }, {
-                      label: 'Constructions spéciales',
-                      backgroundColor: "#EC7063",
-                      data: {{ dep_grp_6|tojson }},
-
-                    }, {
-                      label: 'Terrain',
-                      backgroundColor: "#E6B0AA",
-                      data: {{ dep_grp_7|tojson }},
-
-                    }, {
-                      label: 'Autre',
-                      backgroundColor: "#B2BEB5",
-                      data: {{ dep_grp_8|tojson }},
-
-                    }, {
-                      label: 'Parties communes usage restreint',
-                      backgroundColor: "#bad80a",
-                      data: {{ dep_grp_9|tojson }},
-                    }
-                    ]
-                  },
-                  options: {
-                    legend: {
-                      display: false,
-
-                 },
-                    title: {
-                      display: false,
-                      text: 'blabla'
-                    },
-                    scales: {
-                    xAxes: [{ stacked: true }],
-                    yAxes: [{ stacked: true }]
-                    },
-                    responsive: false
-                  }
-                  });
-            </script>
-        </div>
-    </div>
-</div>
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-12 col-xs-12 col-sm-12 text-center mt-1">
-            <div class="form-group form-inline justify-content-between mb-3">
-                <h4>Table des interventions prévues dans l'analyse du fonds de prévoyance</h4>
-                <div class="form-check">
+            <form action="{{ url_for('bp_fonds_prevoyance.depenses_fdp', usager='admin') }}" method="post" role="form">
+                <label class="fdp-view-toggle" title="Basculer entre la part du syndicat et la part des copropriétaires">
                     {% if toggle == "syndicat": %}
-                        <input type="checkbox" class="form-check-input"  name="toggle" onchange="this.form.submit()">
+                        <input type="checkbox" name="toggle" onchange="this.form.submit()">
                     {% else %}
-                        <input type="checkbox" class="form-check-input"  name="toggle" onchange="this.form.submit()" checked>
+                        <input type="checkbox" name="toggle" onchange="this.form.submit()" checked>
                     {% endif %}
-                        <label class="form-check-label" for="toggle">Copropriétaires</label>
+                    <span>Vue copropriétaires</span>
+                </label>
+            </form>
+        </div>
+
+        <div class="fdp-kpi-grid">
+            <button type="button" class="fdp-kpi fdp-kpi-total" id="fdp-kpi-total">
+                <span class="fdp-kpi-label">Total projeté — 25 ans</span>
+                <span class="fdp-kpi-value" id="fdp-total-projected">—</span>
+                <span class="fdp-kpi-sub">dépenses visibles</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-next" id="fdp-kpi-next">
+                <span class="fdp-kpi-label">Prochaine dépense</span>
+                <span class="fdp-kpi-value" id="fdp-next-year">—</span>
+                <span class="fdp-kpi-sub" id="fdp-next-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-peak" id="fdp-kpi-peak">
+                <span class="fdp-kpi-label">Année la plus coûteuse</span>
+                <span class="fdp-kpi-value" id="fdp-peak-year">—</span>
+                <span class="fdp-kpi-sub" id="fdp-peak-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-group" id="fdp-kpi-group">
+                <span class="fdp-kpi-label">Groupe principal</span>
+                <span class="fdp-kpi-value" id="fdp-main-group">—</span>
+                <span class="fdp-kpi-sub" id="fdp-main-group-sub">—</span>
+            </button>
+            <button type="button" class="fdp-kpi fdp-kpi-count" id="fdp-kpi-count">
+                <span class="fdp-kpi-label">Occurrences projetées</span>
+                <span class="fdp-kpi-value" id="fdp-row-count">—</span>
+                <span class="fdp-kpi-sub">lignes affichées</span>
+            </button>
+        </div>
+
+        <div class="fdp-banner">
+            {% if toggle == "syndicat": %}
+                Analyse courante : dépenses projetées selon la part payée par le syndicat.
+            {% else %}
+                Analyse courante : dépenses projetées selon la part assumée par les copropriétaires.
+            {% endif %}
+        </div>
+
+        <div class="fdp-filter-card">
+            <p class="fdp-filter-title">Groupes Uniformat affichés</p>
+            <div class="fdp-chip-row" id="fdp-group-filters">
+                <button type="button" class="fdp-chip active" data-filter-group="all">Tous</button>
+                <button type="button" class="fdp-chip active" data-filter-group="1">A · Infrastructures</button>
+                <button type="button" class="fdp-chip active" data-filter-group="2">B · Superstructures</button>
+                <button type="button" class="fdp-chip active" data-filter-group="3">C · Aménagements</button>
+                <button type="button" class="fdp-chip active" data-filter-group="4">D · Services</button>
+                <button type="button" class="fdp-chip active" data-filter-group="5">E · Équipements</button>
+                <button type="button" class="fdp-chip active" data-filter-group="6">F · Constructions</button>
+                <button type="button" class="fdp-chip active" data-filter-group="7">G · Terrains</button>
+                <button type="button" class="fdp-chip active" data-filter-group="8">Autre</button>
+                <button type="button" class="fdp-chip active" data-filter-group="9">Z · Usage restreint</button>
+            </div>
+        </div>
+
+        <div class="row mb-4">
+            <div class="col-lg-6 col-md-12 mb-4 mb-lg-0">
+                <div class="fdp-card">
+                    <h2>Dépenses projetées par groupe Uniformat</h2>
+                    <p class="fdp-muted">En dollars actualisés. Cliquez une année dans le graphique pour filtrer le calendrier projeté.</p>
+                    <div class="fdp-chart-wrap"><canvas id="fdp-projected-chart"></canvas></div>
                 </div>
             </div>
+            <div class="col-lg-6 col-md-12">
+                <div class="fdp-card">
+                    <h2>Dépenses réelles vs prévues — 10 ans</h2>
+                    <p class="fdp-muted">Compare les tickets fermés FDP avec les dépenses projetées depuis la dernière analyse.</p>
+                    <div class="fdp-chart-wrap"><canvas id="fdp-actual-chart"></canvas></div>
+                </div>
+            </div>
+        </div>
 
-            <div class="datagrid">
-                <style>
-                    table {
-                        font-family: arial, sans-serif;
-                        font-size: 11px;
-                        border-collapse: collapse;
-                        width: 100%;
-                        z-index: -1;
-                    }
-                    td, th {
-                        border: 1px solid #dddddd;
-                        text-align: left;
-                        padding: 2px;
-                    }
-                    tr:nth-child(even) {
-                        background-color: #dddddd;
-                    }
-                </style>
-                <table id="table_data" class="table table-striped table-bordered" style="width:100%">
+        <div class="fdp-page-header mb-3">
+            <div>
+                <h1>Calendrier projeté des interventions</h1>
+                <p class="fdp-muted">Liste calculée à partir des interventions du fonds de prévoyance, de leur fréquence et des taux d’inflation applicables.</p>
+            </div>
+        </div>
+
+        <div class="fdp-active-filter" id="fdp-active-filter">
+            <span id="fdp-active-filter-text"></span>
+            <button type="button" class="fdp-clear-filter" id="fdp-clear-year-filter">Effacer le filtre d’année</button>
+        </div>
+
+        <div class="fdp-toolbar">
+            <div class="fdp-toolbar-left"><div id="fdp-dt-buttons"></div></div>
+            <div class="fdp-toolbar-right"><div id="fdp-dt-search"></div></div>
+        </div>
+
+        <div class="fdp-card fdp-table-card" id="fdp-table-card">
+            <div class="fdp-table-scroll-top"><div class="fdp-table-scroll-top-inner"></div></div>
+            <div class="fdp-table-scroll">
+                <table id="table_data" class="table">
                     <thead>
-                    <tr>
-                        <th width="60px"><strong>Référence</strong></th>
-                        <th width="60px"><strong>Type</strong></th>
-                        <th width="150px"><strong>Description</strong></th>
-                        <th width="40px"><strong>Groupe</strong></th>
-                        <th width="80px"><strong>Catégorie</strong></th>
-                        <th width="70px"><strong>Coût prévu en $ actualisés</strong></th>
-                        <th width="60px"><strong>Fréquence (ans)</strong></th>
-                        <th width="60px"><strong>Année d'intervention</strong></th>
-                    </tr>
+                        <tr>
+                            <th>Année</th>
+                            <th>Référence</th>
+                            <th>Type</th>
+                            <th>Groupe</th>
+                            <th>Catégorie</th>
+                            <th>Description</th>
+                            <th>Coût actualisé ($)</th>
+                            <th>Fréquence (ans)</th>
+                            <th>Intervenant</th>
+                        </tr>
                     </thead>
-                    {% for item in fill_table %}
-                    <tr>
-                        <td width="60px">{{ item[0] }}</td>
-                        <td width="60px">{{ item[5] }}</td>
-                        <td width="150px">{{ item[1] }}</td>
-                        <td width="40px">{{ item[8] }}</td>
-                        <td width="80px">{{ item[6] }}</td>
-                        <td width="70px">{{ item[3] }}</td>
-                        <td width="60px">{{ item[2] }}</td>
-                        <td width="60px">{{ item[4] }}</td>
-                    </tr>
-                    {% endfor %}
+                    <tbody>
+                        {% for item in fill_table %}
+                        <tr>
+                            <td class="fdp-year">{{ item[4] }}</td>
+                            <td><strong>{{ item[0] }}</strong></td>
+                            <td>
+                                {% if item[5] == "Maintenance" %}
+                                    <span class="fdp-pill fdp-pill-maintenance">Maintenance</span>
+                                {% elif item[5] == "Remplacement" %}
+                                    <span class="fdp-pill fdp-pill-remplacement">Remplacement</span>
+                                {% else %}
+                                    {{ item[5] }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if item[8] %}
+                                    <span class="fdp-pill fdp-pill-group">{{ item[8] }}</span>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>{{ item[6] }}</td>
+                            <td>{{ item[1] }}</td>
+                            <td class="fdp-money">{{ item[3] }}</td>
+                            <td>{{ item[2] }}</td>
+                            <td>{{ item[9] }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
                 </table>
             </div>
         </div>
-    </div>
+    </section>
 </div>
-</form>
-</body>
+
+<script>
+    function getThemeVar(name, fallback) {
+        const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        return value || fallback;
+    }
+
+    function stripHtml(value) {
+        return $('<div>').html(String(value || '')).text();
+    }
+
+    function normalizeText(value) {
+        return stripHtml(value).toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/\s+/g, ' ').trim();
+    }
+
+    function normalizeGroup(value) {
+        return normalizeText(value).replace(/\s*-\s*/g, '-');
+    }
+
+    function formatCurrency(value) {
+        return Number(value || 0).toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' $';
+    }
+
+    function formatCurrencyTooltip(value) {
+        return Number(value || 0).toLocaleString('fr-CA', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' $';
+    }
+
+    function formatCurrencyCompact(value) {
+        const num = Number(value || 0);
+        if (Math.abs(num) >= 1000000) return (num / 1000000).toLocaleString('fr-CA', { maximumFractionDigits: 1 }) + ' M$';
+        if (Math.abs(num) >= 1000) return (num / 1000).toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' k$';
+        return num.toLocaleString('fr-CA', { maximumFractionDigits: 0 }) + ' $';
+    }
+
+    const chartText = getThemeVar('--theme-text', '#243447');
+    const chartMuted = getThemeVar('--theme-text-muted', '#66778a');
+    const chartBorder = getThemeVar('--theme-border', '#d6dde6');
+    const projectedLabels = {{ labels|tojson }};
+    const actualLabels = {{ labels_1|tojson }};
+    const projectedTotal10FromRoute = {{ dep_prevues|tojson }};
+
+    const groupDefinitions = [
+        { id: '1', shortLabel: 'A', label: 'Infrastructures', tablePrefix: 'A-', color: getThemeVar('--theme-chart-equipment', '#4a97ab'), projected: {{ values_1|tojson }}, actual: {{ dep_grp_1|tojson }} },
+        { id: '2', shortLabel: 'B', label: 'Superstructures et enveloppes', tablePrefix: 'B-', color: getThemeVar('--theme-priority-low', '#198754'), projected: {{ values_2|tojson }}, actual: {{ dep_grp_2|tojson }} },
+        { id: '3', shortLabel: 'C', label: 'Aménagements intérieurs', tablePrefix: 'C-', color: getThemeVar('--theme-priority-medium', '#0d6efd'), projected: {{ values_3|tojson }}, actual: {{ dep_grp_3|tojson }} },
+        { id: '4', shortLabel: 'D', label: 'Services', tablePrefix: 'D-', color: getThemeVar('--theme-priority-high', '#f4b400'), projected: {{ values_4|tojson }}, actual: {{ dep_grp_4|tojson }} },
+        { id: '5', shortLabel: 'E', label: 'Équipements et ameublement', tablePrefix: 'E-', color: getThemeVar('--theme-link-complete', '#f59e0b'), projected: {{ values_5|tojson }}, actual: {{ dep_grp_5|tojson }} },
+        { id: '6', shortLabel: 'F', label: 'Constructions spéciales', tablePrefix: 'F-', color: getThemeVar('--theme-priority-critical', '#dc3545'), projected: {{ values_6|tojson }}, actual: {{ dep_grp_6|tojson }} },
+        { id: '7', shortLabel: 'G', label: 'Terrains', tablePrefix: 'G-', color: getThemeVar('--theme-link-delete', '#dc3545'), projected: {{ values_7|tojson }}, actual: {{ dep_grp_7|tojson }} },
+        { id: '8', shortLabel: 'Autre', label: 'Autre', tablePrefix: 'Autre', color: getThemeVar('--theme-kpi-hours', '#5f788a'), projected: {{ values_8|tojson }}, actual: {{ dep_grp_8|tojson }} },
+        { id: '9', shortLabel: 'Z', label: 'Parties communes à usage restreint', tablePrefix: 'Z-', color: getThemeVar('--theme-kpi-age', '#d7dee8'), projected: {{ values_9|tojson }}, actual: {{ dep_grp_9|tojson }} }
+    ];
+
+    let activeGroups = new Set(groupDefinitions.map(group => group.id));
+    let activeYearFilter = null;
+    let table = null;
+    let projectedChart = null;
+    let actualChart = null;
+
+    function getVisibleGroups() {
+        return groupDefinitions.filter(group => activeGroups.has(group.id));
+    }
+
+    function getYearTotals() {
+        const visibleGroups = getVisibleGroups();
+        return projectedLabels.map((year, index) => visibleGroups.reduce((sum, group) => sum + Number(group.projected[index] || 0), 0));
+    }
+
+    function getProjected10Totals() {
+        const visibleGroups = getVisibleGroups();
+        return actualLabels.map(year => {
+            const projectedIndex = projectedLabels.findIndex(projectedYear => String(projectedYear) === String(year));
+            if (projectedIndex === -1) return 0;
+            return visibleGroups.reduce((sum, group) => sum + Number(group.projected[projectedIndex] || 0), 0);
+        });
+    }
+
+    function tableGroupMatches(groupCell) {
+        if (activeGroups.size === groupDefinitions.length) return true;
+        const normalizedCell = normalizeGroup(groupCell);
+        return getVisibleGroups().some(group => {
+            const normalizedPrefix = normalizeGroup(group.tablePrefix);
+            const normalizedLabel = normalizeGroup(group.label);
+            return normalizedCell.startsWith(normalizedPrefix) || normalizedCell.includes(normalizedLabel) || normalizedCell === normalizedLabel;
+        });
+    }
+
+    function setYearFilter(year) {
+        activeYearFilter = year ? String(year) : null;
+        updateActiveFilterBanner();
+        if (table) {
+            table.draw();
+            updateKpis();
+            document.getElementById('fdp-table-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    function updateActiveFilterBanner() {
+        const banner = document.getElementById('fdp-active-filter');
+        const text = document.getElementById('fdp-active-filter-text');
+        if (!activeYearFilter) {
+            banner.classList.remove('show');
+            text.textContent = '';
+            return;
+        }
+        text.textContent = 'Filtre actif : année ' + activeYearFilter;
+        banner.classList.add('show');
+    }
+
+    function updateGroupChips() {
+        $('[data-filter-group]').each(function () {
+            const groupId = $(this).attr('data-filter-group');
+            $(this).toggleClass('active', groupId === 'all' ? activeGroups.size === groupDefinitions.length : activeGroups.has(groupId));
+        });
+    }
+
+    function updateCharts() {
+        projectedChart.data.datasets.forEach(dataset => dataset.hidden = dataset.groupId && !activeGroups.has(dataset.groupId));
+        projectedChart.update();
+        actualChart.data.datasets.forEach(dataset => {
+            if (dataset.groupId) dataset.hidden = !activeGroups.has(dataset.groupId);
+            if (dataset.datasetRole === 'projected-line') dataset.data = getProjected10Totals();
+        });
+        actualChart.update();
+    }
+
+    function getRowCountForYear(year) {
+        if (!table) return 0;
+        let count = 0;
+        table.rows().every(function () {
+            const data = this.data();
+            if (String(stripHtml(data[0])) === String(year) && tableGroupMatches(data[3])) count += 1;
+        });
+        return count;
+    }
+
+    function updateKpis() {
+        const totals = getYearTotals();
+        const total = totals.reduce((sum, value) => sum + Number(value || 0), 0);
+        const firstIndex = totals.findIndex(value => Number(value || 0) > 0);
+        const peakValue = Math.max.apply(null, totals.concat([0]));
+        const peakIndex = totals.findIndex(value => Number(value || 0) === peakValue && peakValue > 0);
+        let mainGroup = null;
+        let mainGroupValue = 0;
+        getVisibleGroups().forEach(group => {
+            const value = group.projected.reduce((sum, current) => sum + Number(current || 0), 0);
+            if (value > mainGroupValue) {
+                mainGroup = group;
+                mainGroupValue = value;
+            }
+        });
+
+        $('#fdp-total-projected').text(formatCurrency(total));
+
+        if (firstIndex >= 0) {
+            const year = projectedLabels[firstIndex];
+            const count = getRowCountForYear(year);
+            $('#fdp-next-year').text(year);
+            $('#fdp-next-sub').text(count + ' intervention' + (count > 1 ? 's' : '') + ' · ' + formatCurrency(totals[firstIndex]));
+            $('#fdp-kpi-next').attr('data-year', year);
+        } else {
+            $('#fdp-next-year').text('—');
+            $('#fdp-next-sub').text('aucune dépense visible');
+            $('#fdp-kpi-next').removeAttr('data-year');
+        }
+
+        if (peakIndex >= 0) {
+            const year = projectedLabels[peakIndex];
+            $('#fdp-peak-year').text(year);
+            $('#fdp-peak-sub').text(formatCurrency(peakValue));
+            $('#fdp-kpi-peak').attr('data-year', year);
+        } else {
+            $('#fdp-peak-year').text('—');
+            $('#fdp-peak-sub').text('aucune dépense visible');
+            $('#fdp-kpi-peak').removeAttr('data-year');
+        }
+
+        if (mainGroup) {
+            $('#fdp-main-group').text(mainGroup.shortLabel + ' · ' + mainGroup.label);
+            $('#fdp-main-group-sub').text(formatCurrency(mainGroupValue));
+            $('#fdp-kpi-group').attr('data-group', mainGroup.id);
+        } else {
+            $('#fdp-main-group').text('—');
+            $('#fdp-main-group-sub').text('aucun groupe visible');
+            $('#fdp-kpi-group').removeAttr('data-group');
+        }
+
+        $('#fdp-row-count').text(table ? table.rows({ filter: 'applied' }).data().length.toLocaleString('fr-CA') : '0');
+    }
+
+    function syncFdpScrollWidth() {
+        const bottom = $('.fdp-table-scroll').get(0);
+        if (!bottom) return;
+        $('.fdp-table-scroll-top-inner').width(bottom.scrollWidth);
+        $('.fdp-table-scroll-top').scrollLeft($('.fdp-table-scroll').scrollLeft());
+        if (table) table.columns.adjust();
+    }
+
+    function createCharts() {
+        Chart.defaults.global.defaultFontColor = chartText;
+
+        projectedChart = new Chart(document.getElementById('fdp-projected-chart'), {
+            type: 'bar',
+            data: {
+                labels: projectedLabels,
+                datasets: groupDefinitions.map(group => ({
+                    label: group.shortLabel + ' · ' + group.label,
+                    groupId: group.id,
+                    backgroundColor: group.color,
+                    borderColor: group.color,
+                    data: group.projected,
+                    borderWidth: 0
+                }))
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: { display: false },
+                tooltips: {
+                    callbacks: {
+                        label: function (tooltipItem, data) {
+                            const dataset = data.datasets[tooltipItem.datasetIndex];
+                            const total = data.datasets.reduce((sum, current) => current.hidden ? sum : sum + Number(current.data[tooltipItem.index] || 0), 0);
+                            return [dataset.label + ' : ' + formatCurrencyTooltip(tooltipItem.yLabel || 0), 'Total de l’année : ' + formatCurrencyTooltip(total)];
+                        }
+                    }
+                },
+                onClick: function (event) {
+                    const points = this.getElementAtEvent(event);
+                    if (points.length) setYearFilter(projectedLabels[points[0]._index]);
+                },
+                scales: {
+                    xAxes: [{ stacked: true, gridLines: { color: chartBorder }, ticks: { fontColor: chartMuted } }],
+                    yAxes: [{ stacked: true, gridLines: { color: chartBorder }, ticks: { beginAtZero: true, fontColor: chartMuted, callback: formatCurrencyCompact } }]
+                }
+            }
+        });
+
+        actualChart = new Chart(document.getElementById('fdp-actual-chart'), {
+            type: 'bar',
+            data: {
+                labels: actualLabels,
+                datasets: [{
+                    label: 'Dépenses prévues',
+                    datasetRole: 'projected-line',
+                    type: 'line',
+                    data: projectedTotal10FromRoute,
+                    borderColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    backgroundColor: 'rgba(13, 110, 253, 0.10)',
+                    pointBackgroundColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    pointBorderColor: getThemeVar('--theme-link-edit', '#0d6efd'),
+                    pointRadius: 4,
+                    pointHoverRadius: 5,
+                    borderWidth: 3,
+                    fill: true,
+                    lineTension: 0.25
+                }].concat(groupDefinitions.map(group => ({
+                    label: 'Réel — ' + group.shortLabel + ' · ' + group.label,
+                    groupId: group.id,
+                    backgroundColor: group.color,
+                    borderColor: group.color,
+                    data: group.actual,
+                    borderWidth: 0
+                })))
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: { display: false },
+                tooltips: {
+                    callbacks: {
+                        label: function (tooltipItem, data) {
+                            const dataset = data.datasets[tooltipItem.datasetIndex];
+                            return (dataset.datasetRole === 'projected-line' ? 'Dépenses prévues : ' : dataset.label + ' : ') + formatCurrencyTooltip(tooltipItem.yLabel || 0);
+                        }
+                    }
+                },
+                onClick: function (event) {
+                    const points = this.getElementAtEvent(event);
+                    if (points.length) setYearFilter(actualLabels[points[0]._index]);
+                },
+                scales: {
+                    xAxes: [{ stacked: true, gridLines: { color: chartBorder }, ticks: { fontColor: chartMuted } }],
+                    yAxes: [{ stacked: true, gridLines: { color: chartBorder }, ticks: { beginAtZero: true, fontColor: chartMuted, callback: formatCurrencyCompact } }]
+                }
+            }
+        });
+    }
+
+    $(document).ready(function () {
+        createCharts();
+
+        $.fn.dataTable.ext.search.push(function (settings, data) {
+            if (settings.nTable.id !== 'table_data') return true;
+            const rowYear = String(stripHtml(data[0] || ''));
+            if (activeYearFilter && rowYear !== String(activeYearFilter)) return false;
+            return tableGroupMatches(data[3]);
+        });
+
+        table = $('#table_data').DataTable({
+            dom: 'Blfrtip',
+            lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'Tous']],
+            pageLength: 25,
+            order: [[0, 'asc']],
+            buttons: [{ extend: 'excelHtml5', title: 'Export CondoFix Dépenses Prévues Fonds de Prévoyance', text: 'Excel' }],
+            language: {
+                decimal: '',
+                emptyTable: 'Aucune donnée disponible dans le tableau',
+                info: 'Affichage de _START_ à _END_ sur _TOTAL_ entrées',
+                infoEmpty: 'Affichage de 0 à 0 sur 0 entrée',
+                infoFiltered: '(filtré à partir de _MAX_ entrées au total)',
+                thousands: ' ',
+                lengthMenu: 'Afficher _MENU_ entrées',
+                loadingRecords: 'Chargement...',
+                processing: 'Traitement...',
+                search: 'Recherche',
+                zeroRecords: 'Aucun résultat trouvé',
+                paginate: { first: 'Premier', last: 'Dernier', next: 'Suivant', previous: 'Précédent' },
+                aria: {
+                    sortAscending: ': activer pour trier la colonne par ordre croissant',
+                    sortDescending: ': activer pour trier la colonne par ordre décroissant'
+                }
+            },
+            initComplete: function () {
+                const wrapper = $('#table_data_wrapper');
+                wrapper.find('.dt-buttons').appendTo('#fdp-dt-buttons');
+                wrapper.find('.dataTables_filter').appendTo('#fdp-dt-search');
+                updateKpis();
+                syncFdpScrollWidth();
+            }
+        });
+
+        table.on('draw', function () {
+            updateKpis();
+            syncFdpScrollWidth();
+        });
+
+        $('#fdp-group-filters').on('click', '[data-filter-group]', function () {
+            const groupId = $(this).attr('data-filter-group');
+            if (groupId === 'all') {
+                activeGroups = new Set(groupDefinitions.map(group => group.id));
+            } else if (activeGroups.size === groupDefinitions.length) {
+                activeGroups = new Set([groupId]);
+            } else if (activeGroups.has(groupId)) {
+                activeGroups.delete(groupId);
+                if (activeGroups.size === 0) activeGroups = new Set(groupDefinitions.map(group => group.id));
+            } else {
+                activeGroups.add(groupId);
+            }
+            updateGroupChips();
+            updateCharts();
+            table.draw();
+            updateKpis();
+        });
+
+        $('#fdp-kpi-total, #fdp-kpi-count').on('click', function () {
+            activeYearFilter = null;
+            activeGroups = new Set(groupDefinitions.map(group => group.id));
+            updateGroupChips();
+            updateCharts();
+            updateActiveFilterBanner();
+            table.draw();
+            updateKpis();
+        });
+
+        $('#fdp-kpi-next, #fdp-kpi-peak').on('click', function () {
+            const year = $(this).attr('data-year');
+            if (year) setYearFilter(year);
+        });
+
+        $('#fdp-kpi-group').on('click', function () {
+            const groupId = $(this).attr('data-group');
+            if (!groupId) return;
+            activeGroups = new Set([groupId]);
+            activeYearFilter = null;
+            updateGroupChips();
+            updateCharts();
+            updateActiveFilterBanner();
+            table.draw();
+            updateKpis();
+        });
+
+        $('#fdp-clear-year-filter').on('click', function () { setYearFilter(null); });
+
+        $('.fdp-table-scroll-top').on('scroll', function () { $('.fdp-table-scroll').scrollLeft($(this).scrollLeft()); });
+        $('.fdp-table-scroll').on('scroll', function () { $('.fdp-table-scroll-top').scrollLeft($(this).scrollLeft()); });
+        $(window).on('resize', syncFdpScrollWidth);
+        setTimeout(syncFdpScrollWidth, 150);
+    });
+</script>
+
 {% endblock content %}


### PR DESCRIPTION
## Summary

This PR modernizes the **Fonds de prévoyance — Analyse des dépenses projetées** page for both administrator and copropriétaire views.

The page now uses the Phase 1–2 CondoFix visual system with KPI cards, theme-aware charts, group filters, a modernized DataTable, improved responsiveness, and clearer financial context around projected and actual reserve fund expenses.

## Changes

* Refactored the projected expenses dashboard UI.
* Added KPI cards for:

  * total projected expenses over the visible 25-year projection window;
  * next projected expense year;
  * highest projected expense year;
  * main Uniformat group;
  * number of projected occurrences displayed.
* Added interactive Uniformat group filters.
* Improved the projected expenses chart by group.
* Improved the actual vs projected 10-year comparison chart.
* Added visual markers for:

  * Début FDP;
  * Année courante.
* Updated the 10-year comparison window to use the official FDP analysis date while avoiding an old frozen window.
* Removed misleading table filtering from the actual vs projected chart.
* Added an admin-only warning when the FDP analysis date appears significantly inconsistent with active projected interventions.
* Consolidated the admin and copropriétaire page behavior into the same template with conditional display logic.
* Preserved the restricted copropriétaire view when the parameter `AccesLimCoprop` is enabled.
* Added page-size selection, search, Excel export, and responsive horizontal scrolling for the projected intervention table.
* Added pills for intervention type and Uniformat group.
* Ensured historical FDP interventions are excluded from active projections.

## Technical notes

* Existing financial projection calculations were preserved.
* `calcul_dep()` was not refactored in this PR.
* Historical FDP rows are excluded from active FDP projections.
* The copropriétaire view continues to respect the existing access restriction parameter.
* The actual vs projected chart compares closed tickets of type **Fonds de prévoyance** with projections from the active analysis, but it does not imply that closed tickets are directly linked to a specific FDP intervention.

## Validation

Tested locally and in production with a real client account.

Validated:

* `/depenses_fdp/admin`
* `/depenses_fdp/coproprios`
* admin view
* copropriétaire view
* restricted copropriétaire graph-only view
* Vue syndicat / Vue copropriétaires toggle
* Uniformat group filters
* KPI filters
* projected chart year click
* year-filter clearing
* DataTable search
* page-size dropdown
* Excel export
* desktop layout
* tablet/mobile responsiveness
* theme compatibility

## Risk

Medium.

This page is part of the financial core of CondoFix. The PR changes the presentation and dashboard behavior, but the underlying projection calculation logic was intentionally preserved.

